### PR TITLE
notification handling

### DIFF
--- a/src/ResponseMapper.php
+++ b/src/ResponseMapper.php
@@ -41,6 +41,14 @@ class ResponseMapper
                 throw new MalformedResponseException('Missing transaction-id in response.');
             }
 
+            if (!array_key_exists('payment-methods', $payment)) {
+                throw new MalformedResponseException('Missing payment method in response.');
+            }
+
+            if (!array_key_exists('payment-method', $payment['payment-methods'])) {
+                throw new MalformedResponseException('Missing payment method in response.');
+            }
+
             //using isset, because array_key_exists only goes 1 layer deep
             if (isset($payment['payment-methods']['payment-method'][0]['url'])) {
                 $redirectUrl = $payment['payment-methods']['payment-method'][0]['url'];

--- a/src/ResponseMapper.php
+++ b/src/ResponseMapper.php
@@ -32,43 +32,43 @@ class ResponseMapper
             throw new MalformedResponseException('Missing transaction state in response.');
         }
 
-        
+
         $statusCollection = $this->getStatusCollection($payment);
-        if ($state === 'success') {
-            if (array_key_exists('transaction-id', $payment)) {
-                $transactionId = $payment['transaction-id'];
-            } else {
-                throw new MalformedResponseException('Missing transaction-id in response.');
-            }
+        if ($state !== 'success') {
+            return new FailureResponse($jsonResponse, $statusCollection);
+        }
 
-            if (!array_key_exists('payment-methods', $payment)) {
-                throw new MalformedResponseException('Missing payment method in response.');
-            }
-
-            if (!array_key_exists('payment-method', $payment['payment-methods'])) {
-                throw new MalformedResponseException('Missing payment method in response.');
-            }
-
-            //using isset, because array_key_exists only goes 1 layer deep
-            if (isset($payment['payment-methods']['payment-method'][0]['url'])) {
-                $redirectUrl = $payment['payment-methods']['payment-method'][0]['url'];
-                $responseObject = new InteractionResponse(
-                    $jsonResponse,
-                    $statusCollection,
-                    $transactionId,
-                    $redirectUrl
-                );
-            } else {
-                $providerTransactionId = $this->retrieveProviderTransactionId($payment);
-                $responseObject = new SuccessResponse(
-                    $jsonResponse,
-                    $statusCollection,
-                    $transactionId,
-                    $providerTransactionId
-                );
-            }
+        if (array_key_exists('transaction-id', $payment)) {
+            $transactionId = $payment['transaction-id'];
         } else {
-            $responseObject = new FailureResponse($jsonResponse, $statusCollection);
+            throw new MalformedResponseException('Missing transaction-id in response.');
+        }
+
+        if (!array_key_exists('payment-methods', $payment)) {
+            throw new MalformedResponseException('Missing payment method in response.');
+        }
+
+        if (!array_key_exists('payment-method', $payment['payment-methods'])) {
+            throw new MalformedResponseException('Missing payment method in response.');
+        }
+
+        //using isset, because array_key_exists only goes 1 layer deep
+        if (isset($payment['payment-methods']['payment-method'][0]['url'])) {
+            $redirectUrl = $payment['payment-methods']['payment-method'][0]['url'];
+            $responseObject = new InteractionResponse(
+                $jsonResponse,
+                $statusCollection,
+                $transactionId,
+                $redirectUrl
+            );
+        } else {
+            $providerTransactionId = $this->retrieveProviderTransactionId($payment);
+            $responseObject = new SuccessResponse(
+                $jsonResponse,
+                $statusCollection,
+                $transactionId,
+                $providerTransactionId
+            );
         }
 
         return $responseObject;
@@ -120,7 +120,7 @@ class ResponseMapper
         foreach ($statuses as $st) {
             if (isset($st['status']['provider-transaction-id'])) {
                 if ($result !== null) {
-
+                    // Add check
                 }
                 $result = $st['status']['provider-transaction-id'];
             }

--- a/src/ResponseMapper.php
+++ b/src/ResponseMapper.php
@@ -51,7 +51,7 @@ class ResponseMapper
                     $redirectUrl
                 );
             } else {
-                $providerTransactionId = $payment['statuses'][0]['status']['provider-transaction-id'];
+                $providerTransactionId = $this->retrieveProviderTransactionId($payment);
                 $responseObject = new SuccessResponse(
                     $jsonResponse,
                     $statusCollection,
@@ -99,5 +99,25 @@ class ResponseMapper
         }
 
         return $collection;
+    }
+
+    /**
+     * @param $payment
+     * @return mixed
+     */
+    private function retrieveProviderTransactionId($payment)
+    {
+        $result = null;
+        $statuses = $payment['statuses'];
+        foreach ($statuses as $st) {
+            if (isset($st['status']['provider-transaction-id'])) {
+                if ($result !== null) {
+
+                }
+                $result = $st['status']['provider-transaction-id'];
+            }
+        }
+
+        return $result;
     }
 }

--- a/src/SuccessResponse.php
+++ b/src/SuccessResponse.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Wirecard\PaymentSdk;
+
+class SuccessResponse extends Response
+{
+    /**
+     * @var string
+     */
+    private $transactionId;
+
+    /**
+     * @var string
+     */
+    private $providerTransactionId;
+
+
+    public function __construct($rawData, $statusCollection, $transactionId, $providerTransactionId)
+    {
+        parent::__construct($rawData, $statusCollection);
+        $this->transactionId = $transactionId;
+        $this->providerTransactionId = $providerTransactionId;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTransactionId()
+    {
+        return $this->transactionId;
+    }
+
+    /**
+     * @return string
+     */
+    public function getProviderTransactionId()
+    {
+        return $this->providerTransactionId;
+    }
+}

--- a/src/TransactionService.php
+++ b/src/TransactionService.php
@@ -7,6 +7,7 @@ use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\Request;
 use Monolog\Handler\ErrorLogHandler;
 use Monolog\Logger;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -161,5 +162,16 @@ class TransactionService
         ));
 
         return $this->getResponseMapper()->map($response->getBody());
+    }
+
+    /**
+     * @param ResponseInterface $httpResponse
+     * @throws MalformedResponseException|\RuntimeException
+     * @return FailureResponse|InteractionResponse
+     */
+    public function handleNotification(ResponseInterface $httpResponse)
+    {
+        $contents = $httpResponse->getBody()->getContents();
+        return $this->getResponseMapper()->map($contents);
     }
 }

--- a/src/TransactionService.php
+++ b/src/TransactionService.php
@@ -165,13 +165,11 @@ class TransactionService
     }
 
     /**
-     * @param ResponseInterface $httpResponse
-     * @throws MalformedResponseException|\RuntimeException
+     * @param string $jsonResponse
      * @return FailureResponse|InteractionResponse
      */
-    public function handleNotification(ResponseInterface $httpResponse)
+    public function handleNotification($jsonResponse)
     {
-        $contents = $httpResponse->getBody()->getContents();
-        return $this->getResponseMapper()->map($contents);
+        return $this->getResponseMapper()->map($jsonResponse);
     }
 }

--- a/test/ResponseMapperUTest.php
+++ b/test/ResponseMapperUTest.php
@@ -3,6 +3,7 @@ namespace WirecardTest\PaymentSdk;
 
 use Wirecard\PaymentSdk\FailureResponse;
 use Wirecard\PaymentSdk\InteractionResponse;
+use Wirecard\PaymentSdk\MalformedResponseException;
 use Wirecard\PaymentSdk\ResponseMapper;
 use Wirecard\PaymentSdk\SuccessResponse;
 
@@ -61,6 +62,52 @@ class ResponseMapperUTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf(FailureResponse::class, $mapped);
 
         $this->assertCount(2, $mapped->getStatusCollection());
+    }
+
+    /**
+     * @expectedException \Wirecard\PaymentSdk\MalformedResponseException
+     */
+    public function testTransactionStateSuccessNoPaymentMethodThrowsMalformedResponseException()
+    {
+        $response = json_encode([
+            self::PAYMENT => [
+                self::TRANSACTION_ID => '12345',
+                self::TRANSACTION_STATE => 'success',
+                self::STATUSES => [['status' =>
+                    [
+                        self::STATUS_CODE => '200',
+                        self::STATUS_DESCRIPTION => 'UnitTest',
+                        self::STATUS_SEVERITY => 'information'
+                    ],
+                ]]
+            ]
+        ]);
+
+        $this->mapper->map($response);
+    }
+
+    /**
+     * @expectedException \Wirecard\PaymentSdk\MalformedResponseException
+     */
+    public function testTransactionStateSuccessNoSinglePaymentMethodThrowsMalformedResponseException()
+    {
+        $response = json_encode([
+            self::PAYMENT => [
+                self::TRANSACTION_ID => '12345',
+                self::TRANSACTION_STATE => 'success',
+                self::STATUSES => [['status' =>
+                    [
+                        self::STATUS_CODE => '200',
+                        self::STATUS_DESCRIPTION => 'UnitTest',
+                        self::STATUS_SEVERITY => 'information'
+                    ],
+                ]],
+                self::PAYMENT_METHODS => [
+                ]
+            ]
+        ]);
+
+        $this->mapper->map($response);
     }
 
     public function testTransactionStateSuccessReturnsFilledInteractionResponseObject()

--- a/test/ResponseMapperUTest.php
+++ b/test/ResponseMapperUTest.php
@@ -237,12 +237,12 @@ class ResponseMapperUTest extends \PHPUnit_Framework_TestCase
                 self::TRANSACTION_STATE => 'success',
                 self::STATUSES => [
                     ['status' =>
-                    [
-                        self::STATUS_CODE => '500',
-                        self::STATUS_DESCRIPTION => 'UnitTest: Earlier error.',
-                        self::STATUS_SEVERITY => 'error'
+                        [
+                            self::STATUS_CODE => '500',
+                            self::STATUS_DESCRIPTION => 'UnitTest: Earlier error.',
+                            self::STATUS_SEVERITY => 'error'
+                        ],
                     ],
-                ],
                     ['status' =>
                         [
                             self::STATUS_CODE => '201',
@@ -250,7 +250,7 @@ class ResponseMapperUTest extends \PHPUnit_Framework_TestCase
                             self::PROVIDER_TRANSACTION_ID => '55',
                             self::STATUS_SEVERITY => 'information'
                         ]
-    ]
+                    ]
                 ],
                 self::PAYMENT_METHODS => [
                     self::PAYMENT_METHOD => [
@@ -271,7 +271,6 @@ class ResponseMapperUTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($response, $result->getRawData());
         $this->assertEquals('55', $result->getProviderTransactionId());
     }
-
 
 
     private function removeResponseKey($response, array $key)

--- a/test/ResponseMapperUTest.php
+++ b/test/ResponseMapperUTest.php
@@ -182,6 +182,51 @@ class ResponseMapperUTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('55', $result->getProviderTransactionId());
     }
 
+    public function testTransactionStateSuccessWithMoreStatusesReturnsSuccessResponseObject()
+    {
+        $response = json_encode([
+            self::PAYMENT => [
+                self::TRANSACTION_ID => '12345',
+                self::TRANSACTION_STATE => 'success',
+                self::STATUSES => [
+                    ['status' =>
+                    [
+                        self::STATUS_CODE => '500',
+                        self::STATUS_DESCRIPTION => 'UnitTest: Earlier error.',
+                        self::STATUS_SEVERITY => 'error'
+                    ],
+                ],
+                    ['status' =>
+                        [
+                            self::STATUS_CODE => '201',
+                            self::STATUS_DESCRIPTION => 'UnitTest: The resource was successfully created.',
+                            self::PROVIDER_TRANSACTION_ID => '55',
+                            self::STATUS_SEVERITY => 'information'
+                        ]
+    ]
+                ],
+                self::PAYMENT_METHODS => [
+                    self::PAYMENT_METHOD => [
+                        [
+                            self::PAYMENT_METHOD_NAME => 'paypal'
+                        ]
+                    ]
+                ]
+            ]
+        ]);
+
+        $result = $this->mapper->map($response);
+
+        $this->assertInstanceOf(SuccessResponse::class, $result);
+
+        $this->assertEquals('12345', $result->getTransactionId());
+        $this->assertCount(2, $result->getStatusCollection());
+        $this->assertEquals($response, $result->getRawData());
+        $this->assertEquals('55', $result->getProviderTransactionId());
+    }
+
+
+
     private function removeResponseKey($response, array $key)
     {
         if (count($key) > 1) {

--- a/test/TransactionServiceUTest.php
+++ b/test/TransactionServiceUTest.php
@@ -216,11 +216,7 @@ class TransactionServiceUTest extends \PHPUnit_Framework_TestCase
 
     public function testHandleNotificationHappyPath()
     {
-        $response = $this->createMock('Psr\Http\Message\ResponseInterface');
-        $body = $this->createMock('Psr\Http\Message\StreamInterface');
-        $response->method('getBody')->willReturn($body);
         $validJsonContent = '{dummy-field: "dummy-value"}';
-        $body->method('getContents')->willReturn($validJsonContent);
 
         $responseMapper = $this->createMock('Wirecard\PaymentSdk\ResponseMapper');
         $interactionResponse = new InteractionResponse('dummy', new StatusCollection(), 'x', 'y');
@@ -228,24 +224,9 @@ class TransactionServiceUTest extends \PHPUnit_Framework_TestCase
 
         $this->instance = new TransactionService($this->config, null, null, null, $responseMapper);
 
-        $result = $this->instance->handleNotification($response);
+        $result = $this->instance->handleNotification($validJsonContent);
 
         $this->assertEquals($interactionResponse, $result);
-    }
-
-    /**
-     * @expectedException \RuntimeException
-     */
-    public function testHandleNotificationRuntimeException()
-    {
-        $response = $this->createMock('Psr\Http\Message\ResponseInterface');
-        $body = $this->createMock('Psr\Http\Message\StreamInterface');
-        $response->method('getBody')->willReturn($body);
-        $body->method('getContents')->willThrowException(new \RuntimeException());
-
-        $this->instance = new TransactionService($this->config, null, null, null);
-
-        $this->instance->handleNotification($response);
     }
 
     /**
@@ -253,18 +234,14 @@ class TransactionServiceUTest extends \PHPUnit_Framework_TestCase
      */
     public function testHandleNotificationMalformedResponseException()
     {
-        $response = $this->createMock('Psr\Http\Message\ResponseInterface');
-        $body = $this->createMock('Psr\Http\Message\StreamInterface');
-        $response->method('getBody')->willReturn($body);
         $validJsonContent = '{dummy-field: "dummy-value"}';
-        $body->method('getContents')->willReturn($validJsonContent);
 
         $responseMapper = $this->createMock('Wirecard\PaymentSdk\ResponseMapper');
         $responseMapper->method('map')->with($validJsonContent)->willThrowException(new MalformedResponseException());
 
         $this->instance = new TransactionService($this->config, null, null, null, $responseMapper);
 
-        $this->instance->handleNotification($response);
+        $this->instance->handleNotification($validJsonContent);
     }
 
     protected function getTransactionMock()


### PR DESCRIPTION
There was a change in ResponseMapper according to [the sample notification](https://document-center.wirecard.com/display/PTD/Debit+for+paypal)
The expected statuses collection does not look like this:
```
self::STATUSES => [
                    [
                        self::STATUS_CODE => '200',
                        self::STATUS_DESCRIPTION => 'UnitTest',
                        self::STATUS_SEVERITY => 'warning'
                    ],
                    [
                        self::STATUS_CODE => '500',
                        self::STATUS_DESCRIPTION => 'UnitTest Error',
                        self::STATUS_SEVERITY => 'error'
                    ],
                ]
```
But like this:
```
self::STATUSES => [
                    ['status' =>
                        [
                            self::STATUS_CODE => '200',
                            self::STATUS_DESCRIPTION => 'UnitTest',
                            self::STATUS_SEVERITY => 'warning'
                        ]],
                    ['status' =>
                        [
                            self::STATUS_CODE => '500',
                            self::STATUS_DESCRIPTION => 'UnitTest Error',
                            self::STATUS_SEVERITY => 'error'
                        ],
                    ]]
```

Please review whether it's OK this way.