### PR TITLE
added entity for 3D credit card transactions

### DIFF
--- a/src/ThreeDCreditCardTransaction.php
+++ b/src/ThreeDCreditCardTransaction.php
@@ -30,47 +30,51 @@
  * Please do not use the plugin if you do not agree to these terms of use!
  */
 
-namespace WirecardTest\PaymentSdk;
+namespace Wirecard\PaymentSdk;
 
-use Wirecard\PaymentSdk\_3DCreditCardTransaction;
-use Wirecard\PaymentSdk\Money;
-
-// @codingStandardsIgnoreStart
-class _3DCreditCardTransactionUTest extends \PHPUnit_Framework_TestCase
-// @codingStandardsIgnoreEnd
+/**
+ * Class CreditCard3DTransaction
+ * @package Wirecard\PaymentSdk
+ *
+ * An immutable entity representing a 3D payment with a credit card.
+ */
+class ThreeDCreditCardTransaction extends CreditCardTransaction
 {
-    const NOTIFICATION_TEST_URL = 'test URL';
-    const TERM_TEST_URL = 'term test URL';
     /**
-     * @var _3DCreditCardTransaction
+     * @var string
      */
-    private $transaction;
+    private $notificationUrl;
 
     /**
-     * @var Money
+     * @var string
      */
-    private $amount;
+    private $termUrl;
 
-    const SAMPLE_TRANSACTION_ID = '542';
-
-    public function setUp()
+    /**
+     * _3DCreditCardTransaction constructor.
+     * @param string $notificationUrl
+     * @param string $termUrl
+     */
+    public function __construct($money, $transactionId, $notificationUrl, $termUrl)
     {
-        $this->amount = new Money(8.5, 'EUR');
-        $this->transaction = new _3DCreditCardTransaction(
-            $this->amount,
-            self::SAMPLE_TRANSACTION_ID,
-            self::NOTIFICATION_TEST_URL,
-            self::TERM_TEST_URL
-        );
+        parent::__construct($money, $transactionId);
+        $this->notificationUrl = $notificationUrl;
+        $this->termUrl = $termUrl;
     }
 
-    public function testGetNotificationUrl()
+    /**
+     * @return string
+     */
+    public function getNotificationUrl()
     {
-        $this->assertEquals(self::NOTIFICATION_TEST_URL, $this->transaction->getNotificationUrl());
+        return $this->notificationUrl;
     }
 
-    public function testGetTermUrl()
+    /**
+     * @return string
+     */
+    public function getTermUrl()
     {
-        $this->assertEquals(self::TERM_TEST_URL, $this->transaction->getTermUrl());
+        return $this->termUrl;
     }
 }

--- a/src/_3DCreditCardTransaction.php
+++ b/src/_3DCreditCardTransaction.php
@@ -30,38 +30,53 @@
  * Please do not use the plugin if you do not agree to these terms of use!
  */
 
-namespace WirecardTest\PaymentSdk;
+namespace Wirecard\PaymentSdk;
 
-use Wirecard\PaymentSdk\CreditCardTransaction;
-use Wirecard\PaymentSdk\Money;
-
-class CreditCardTransactionUTest extends \PHPUnit_Framework_TestCase
+/**
+ * Class CreditCard3DTransaction
+ * @package Wirecard\PaymentSdk
+ *
+ * An immutable entity representing a 3D payment with a credit card.
+ */
+// @codingStandardsIgnoreStart
+class _3DCreditCardTransaction extends CreditCardTransaction
+// @codingStandardsIgnoreEnd
 {
     /**
-     * @var CreditCardTransaction
+     * @var string
      */
-    private $ccTransaction;
+    private $notificationUrl;
 
     /**
-     * @var Money
+     * @var string
      */
-    private $amount;
+    private $termUrl;
 
-    const SAMPLE_TRANSACTION_ID = '542';
-
-    public function setUp()
+    /**
+     * _3DCreditCardTransaction constructor.
+     * @param string $notificationUrl
+     * @param string $termUrl
+     */
+    public function __construct($money, $transactionId, $notificationUrl, $termUrl)
     {
-        $this->amount = new Money(8.5, 'EUR');
-        $this->ccTransaction = new CreditCardTransaction($this->amount, self::SAMPLE_TRANSACTION_ID);
+        parent::__construct($money, $transactionId);
+        $this->notificationUrl = $notificationUrl;
+        $this->termUrl = $termUrl;
     }
 
-    public function testGetAmount()
+    /**
+     * @return string
+     */
+    public function getNotificationUrl()
     {
-        $this->assertEquals($this->amount, $this->ccTransaction->getAmount());
+        return $this->notificationUrl;
     }
 
-    public function testGetTransactionId()
+    /**
+     * @return string
+     */
+    public function getTermUrl()
     {
-        $this->assertEquals(self::SAMPLE_TRANSACTION_ID, $this->ccTransaction->getTransactionId());
+        return $this->termUrl;
     }
 }

--- a/test/ThreeDCreditCardTransactionUTest.php
+++ b/test/ThreeDCreditCardTransactionUTest.php
@@ -30,53 +30,45 @@
  * Please do not use the plugin if you do not agree to these terms of use!
  */
 
-namespace Wirecard\PaymentSdk;
+namespace WirecardTest\PaymentSdk;
 
-/**
- * Class CreditCard3DTransaction
- * @package Wirecard\PaymentSdk
- *
- * An immutable entity representing a 3D payment with a credit card.
- */
-// @codingStandardsIgnoreStart
-class _3DCreditCardTransaction extends CreditCardTransaction
-// @codingStandardsIgnoreEnd
+use Wirecard\PaymentSdk\ThreeDCreditCardTransaction;
+use Wirecard\PaymentSdk\Money;
+
+class ThreeDCreditCardTransactionUTest extends \PHPUnit_Framework_TestCase
 {
+    const NOTIFICATION_TEST_URL = 'test URL';
+    const TERM_TEST_URL = 'term test URL';
     /**
-     * @var string
+     * @var ThreeDCreditCardTransaction
      */
-    private $notificationUrl;
+    private $transaction;
 
     /**
-     * @var string
+     * @var Money
      */
-    private $termUrl;
+    private $amount;
 
-    /**
-     * _3DCreditCardTransaction constructor.
-     * @param string $notificationUrl
-     * @param string $termUrl
-     */
-    public function __construct($money, $transactionId, $notificationUrl, $termUrl)
+    const SAMPLE_TRANSACTION_ID = '542';
+
+    public function setUp()
     {
-        parent::__construct($money, $transactionId);
-        $this->notificationUrl = $notificationUrl;
-        $this->termUrl = $termUrl;
+        $this->amount = new Money(8.5, 'EUR');
+        $this->transaction = new ThreeDCreditCardTransaction(
+            $this->amount,
+            self::SAMPLE_TRANSACTION_ID,
+            self::NOTIFICATION_TEST_URL,
+            self::TERM_TEST_URL
+        );
     }
 
-    /**
-     * @return string
-     */
-    public function getNotificationUrl()
+    public function testGetNotificationUrl()
     {
-        return $this->notificationUrl;
+        $this->assertEquals(self::NOTIFICATION_TEST_URL, $this->transaction->getNotificationUrl());
     }
 
-    /**
-     * @return string
-     */
-    public function getTermUrl()
+    public function testGetTermUrl()
     {
-        return $this->termUrl;
+        $this->assertEquals(self::TERM_TEST_URL, $this->transaction->getTermUrl());
     }
 }

--- a/test/_3DCreditCardTransactionUTest.php
+++ b/test/_3DCreditCardTransactionUTest.php
@@ -32,15 +32,19 @@
 
 namespace WirecardTest\PaymentSdk;
 
-use Wirecard\PaymentSdk\CreditCardTransaction;
+use Wirecard\PaymentSdk\_3DCreditCardTransaction;
 use Wirecard\PaymentSdk\Money;
 
-class CreditCardTransactionUTest extends \PHPUnit_Framework_TestCase
+// @codingStandardsIgnoreStart
+class _3DCreditCardTransactionUTest extends \PHPUnit_Framework_TestCase
+// @codingStandardsIgnoreEnd
 {
+    const NOTIFICATION_TEST_URL = 'test URL';
+    const TERM_TEST_URL = 'term test URL';
     /**
-     * @var CreditCardTransaction
+     * @var _3DCreditCardTransaction
      */
-    private $ccTransaction;
+    private $transaction;
 
     /**
      * @var Money
@@ -52,16 +56,21 @@ class CreditCardTransactionUTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->amount = new Money(8.5, 'EUR');
-        $this->ccTransaction = new CreditCardTransaction($this->amount, self::SAMPLE_TRANSACTION_ID);
+        $this->transaction = new _3DCreditCardTransaction(
+            $this->amount,
+            self::SAMPLE_TRANSACTION_ID,
+            self::NOTIFICATION_TEST_URL,
+            self::TERM_TEST_URL
+        );
     }
 
-    public function testGetAmount()
+    public function testGetNotificationUrl()
     {
-        $this->assertEquals($this->amount, $this->ccTransaction->getAmount());
+        $this->assertEquals(self::NOTIFICATION_TEST_URL, $this->transaction->getNotificationUrl());
     }
 
-    public function testGetTransactionId()
+    public function testGetTermUrl()
     {
-        $this->assertEquals(self::SAMPLE_TRANSACTION_ID, $this->ccTransaction->getTransactionId());
+        $this->assertEquals(self::TERM_TEST_URL, $this->transaction->getTermUrl());
     }
 }


### PR DESCRIPTION
After discussions in the team we chose the name _3DCreditCardTransaction for this class, and disabled phpcs for the class name.