### PR TITLE
three D response mapper: added MD

### DIFF
--- a/src/RequestMapper.php
+++ b/src/RequestMapper.php
@@ -35,6 +35,7 @@ namespace Wirecard\PaymentSdk;
 class RequestMapper
 {
     const PARAM_TRANSACTION_TYPE = 'transaction-type';
+    const CCARD_AUTHORIZATION = 'authorization';
     /**
      * @var Config
      */
@@ -120,7 +121,7 @@ class RequestMapper
     private function getSpecificPropertiesForCreditCard(CreditCardTransaction $transaction)
     {
         $specificProperties = [
-            self::PARAM_TRANSACTION_TYPE => 'authorization',
+            self::PARAM_TRANSACTION_TYPE => self::CCARD_AUTHORIZATION,
             'card-token' => [
                 'token-id' => $transaction->getTokenId(),
             ],

--- a/src/ResponseMapper.php
+++ b/src/ResponseMapper.php
@@ -218,11 +218,12 @@ class ResponseMapper
         } else {
             $fields->add('PaReq', (string)$threeD->{'pareq'});
         }
-        if (isset($threeD->md)) {
-            $fields->add('MD', (string)$threeD->md);
-        } else {
-            $fields->add('MD', '');
-        }
+
+        $fields->add(
+            'MD',
+            '{ enrollment-check-transaction-id:' . $response->{'transaction-id'}
+            .  ', operation-type:' . RequestMapper::CCARD_AUTHORIZATION . ' }'
+        );
 
         return new FormInteractionResponse($payload, $status, $redirectUrl, $fields);
     }

--- a/test/ResponseMapperUTest.php
+++ b/test/ResponseMapperUTest.php
@@ -209,7 +209,6 @@ class ResponseMapperUTest extends \PHPUnit_Framework_TestCase
                         <three-d>
                             <acs-url>https://www.example.com/acs</acs-url>
                             <pareq>request</pareq>
-                            <md>testMd</md>
                         </three-d>
                     </payment>';
         $transaction = $this->createMock(ThreeDCreditCardTransaction::class);
@@ -221,6 +220,10 @@ class ResponseMapperUTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf(FormInteractionResponse::class, $mapped);
         $this->assertEquals($payload, $mapped->getRawData());
+        $this->assertEquals(
+            '{ enrollment-check-transaction-id:12345, operation-type:authorization }',
+            $mapped->getFormFields()->getIterator()['MD']
+        );
     }
 
     public function testWithValidResponseCreditCardTransactionReturnsSuccessResponse()


### PR DESCRIPTION
3D response: added MD with the content
 - transaction ID (as received in the response of the enrollment check)
- operation type (for now hard-coded authorization)