### PR TITLE
SEPA: pay

### DIFF
--- a/examples/Sepa/pay-data-entry.html
+++ b/examples/Sepa/pay-data-entry.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Reserve payment: SEPA</title>
+</head>
+<body>
+<form action="reserve.php" method="post">
+    <p>
+        <label for="iban">IBAN:</label><br>
+        <input id="iban" name="iban" value="DE42512308000000060004" style="width:300px"/>
+    </p>
+
+    <p>
+        <label for="bic">BIC:</label><br>
+        <input id="bic" name="bic" value="" style="width:300px"/><br>
+        e.g. WIREDEMMXXX
+    </p>
+
+    <input type="submit"/>
+</form>
+
+</body>
+</html>

--- a/examples/Sepa/pay-data-entry.html
+++ b/examples/Sepa/pay-data-entry.html
@@ -5,7 +5,7 @@
     <title>Reserve payment: SEPA</title>
 </head>
 <body>
-<form action="reserve.php" method="post">
+<form action="pay.php" method="post">
     <p>
         <label for="iban">IBAN:</label><br>
         <input id="iban" name="iban" value="DE42512308000000060004" style="width:300px"/>

--- a/examples/Sepa/pay.php
+++ b/examples/Sepa/pay.php
@@ -24,10 +24,14 @@ $amount = new Money(12.59, 'EUR');
 // Since payment method may have a different merchant ID, a config collection is created.
 $configCollection = new Config\PaymentMethodConfigCollection();
 
-// Create and add a configuration object with the settings for credit card
+// Create and add a configuration object with the settings for SEPA
 $sepaMId = '4c901196-eff7-411e-82a3-5ef6b6860d64';
 $sepaKey = 'ecdf5990-0372-47cd-a55d-037dccfe9d25';
 $sepaDdConfig = new Config\PaymentMethodConfig(SepaTransaction::DIRECT_DEBIT, $sepaMId, $sepaKey);
+
+// In order to execute a pay transaction you also have to provide your creditor ID.
+// Please add it to the config as a specific property with the key 'creditor-id'.
+$sepaDdConfig->addSpecificProperty('creditor-id','DE98ZZZ09999999999');
 $configCollection->add($sepaDdConfig);
 
 // The basic configuration requires the base URL for Wirecard and the username and password for the HTTP requests.

--- a/examples/Sepa/pay.php
+++ b/examples/Sepa/pay.php
@@ -1,0 +1,85 @@
+<?php
+
+// # SEPA amount payment
+// The method `pay` of the _transactionService_ provides the means
+// to execute a payment with an amount (also known as debit).
+
+// To include the necessary files, use the composer for PSR-4 autoloading.
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Wirecard\PaymentSdk\Config;
+use Wirecard\PaymentSdk\Entity\AccountHolder;
+use Wirecard\PaymentSdk\Entity\Mandate;
+use Wirecard\PaymentSdk\Response\FailureResponse;
+use Wirecard\PaymentSdk\Entity\Money;
+use Wirecard\PaymentSdk\Response\SuccessResponse;
+use Wirecard\PaymentSdk\Transaction\SepaTransaction;
+use Wirecard\PaymentSdk\TransactionService;
+
+// Create a money object as amount which has to be payed by the consumer.
+$amount = new Money(12.59, 'EUR');
+
+// ### Config
+
+// Since payment method may have a different merchant ID, a config collection is created.
+$configCollection = new Config\PaymentMethodConfigCollection();
+
+// Create and add a configuration object with the settings for credit card
+$sepaMId = '4c901196-eff7-411e-82a3-5ef6b6860d64';
+$sepaKey = 'ecdf5990-0372-47cd-a55d-037dccfe9d25';
+$sepaDdConfig = new Config\PaymentMethodConfig(SepaTransaction::DIRECT_DEBIT, $sepaMId, $sepaKey);
+$configCollection->add($sepaDdConfig);
+
+// The basic configuration requires the base URL for Wirecard and the username and password for the HTTP requests.
+$baseUrl = 'https://api-test.wirecard.com';
+$httpUser = '70000-APITEST-AP';
+$httpPass = 'qD2wzQ_hrc!8';
+
+// A default currency can also be provided.
+$config = new Config\Config($baseUrl, $httpUser, $httpPass, $configCollection, 'EUR');
+
+
+// ## Transaction
+
+// Create a `CreditCardTransaction` object, which contains all relevant data for the payment process.
+// The token is required as reference to the credit card data.
+$transaction = new SepaTransaction();
+$transaction->setAmount($amount);
+$transaction->setIban($_POST['iban']);
+
+if (null !== $_POST['bic']) {
+    $transaction->setBic($_POST['bic']);
+}
+
+$accountHolder = new AccountHolder('Doe');
+$accountHolder->setFirstName('Jane');
+$transaction->setAccountHolder($accountHolder);
+$mandate = new Mandate('12345678');
+$mandate->setSignedDate(strtotime('2015-08-27'));
+$transaction->setMandate($mandate);
+
+// The service is used to execute the reservation (authorization) operation itself. A response object is returned.
+$transactionService = new TransactionService($config);
+$response = $transactionService->pay($transaction);
+
+// ## Response handling
+
+// The response from the service can be used for disambiguation.
+// In case of a successful transaction, a `SuccessResponse` object is returned.
+if ($response instanceof SuccessResponse) {
+    echo sprintf('Payment with id %s successfully completed.<br>', $response->getTransactionId());
+
+// In case of a failed transaction, a `FailureResponse` object is returned.
+} elseif ($response instanceof FailureResponse) {
+    // In our example we iterate over all errors and display them in a raw state.
+    // You should handle them based on the given severity as error, warning or information.
+    foreach ($response->getStatusCollection() as $status) {
+        /**
+         * @var $status \Wirecard\PaymentSdk\Entity\Status
+         */
+        $severity = ucfirst($status->getSeverity());
+        $code = $status->getCode();
+        $description = $status->getDescription();
+        echo sprintf('%s with code %s and message "%s" occured.<br>', $severity, $code, $description);
+    }
+}

--- a/examples/Sepa/reserve-data-entry.html
+++ b/examples/Sepa/reserve-data-entry.html
@@ -5,6 +5,20 @@
     <title>Reserve payment: SEPA</title>
 </head>
 <body>
+<form action="reserve.php" method="post">
+    <p>
+        <label for="iban">IBAN:</label><br>
+        <input id="iban" name="iban" value="DE42512308000000060004" style="width:300px"/>
+    </p>
+
+    <p>
+        <label for="bic">BIC:</label><br>
+        <input id="bic" name="bic" value="" style="width:300px"/><br>
+        e.g. WIREDEMMXXX
+    </p>
+
+    <input type="submit"/>
+</form>
 
 </body>
 </html>

--- a/examples/Sepa/reserve-data-entry.html
+++ b/examples/Sepa/reserve-data-entry.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Reserve payment: SEPA</title>
+</head>
+<body>
+
+</body>
+</html>

--- a/examples/Sepa/reserve.php
+++ b/examples/Sepa/reserve.php
@@ -46,7 +46,11 @@ $config = new Config\Config($baseUrl, $httpUser, $httpPass, $configCollection, '
 // The token is required as reference to the credit card data.
 $transaction = new SepaTransaction();
 $transaction->setAmount($amount);
-$transaction->setIban('DE42512308000000060004');
+$transaction->setIban($_POST['iban']);
+
+if (null !== $_POST['bic']) {
+    $transaction->setBic($_POST['bic']);
+}
 
 $accountHolder = new AccountHolder('Doe');
 $accountHolder->setFirstName('Jane');

--- a/examples/Sepa/reserve.php
+++ b/examples/Sepa/reserve.php
@@ -1,0 +1,79 @@
+<?php
+
+// # SEPA amount reservation
+// The method `reserve` of the _transactionService_ provides the means
+// to reserve an amount (also known as authorization).
+
+// ## Required objects
+
+// To include the necessary files, use the composer for PSR-4 autoloading.
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Wirecard\PaymentSdk\Config;
+use Wirecard\PaymentSdk\Entity\AccountHolder;
+use Wirecard\PaymentSdk\Response\FailureResponse;
+use Wirecard\PaymentSdk\Entity\Money;
+use Wirecard\PaymentSdk\Response\SuccessResponse;
+use Wirecard\PaymentSdk\Transaction\SepaTransaction;
+use Wirecard\PaymentSdk\TransactionService;
+
+// Create a money object as amount which has to be payed by the consumer.
+$amount = new Money(12.59, 'EUR');
+
+// ### Config
+
+// Since payment method may have a different merchant ID, a config collection is created.
+$configCollection = new Config\PaymentMethodConfigCollection();
+
+// Create and add a configuration object with the settings for credit card
+$sepaMId = '4c901196-eff7-411e-82a3-5ef6b6860d64';
+$sepaKey = 'ecdf5990-0372-47cd-a55d-037dccfe9d25';
+$sepaDdConfig = new Config\PaymentMethodConfig(SepaTransaction::DIRECT_DEBIT, $sepaMId, $sepaKey);
+$configCollection->add($sepaDdConfig);
+
+// The basic configuration requires the base URL for Wirecard and the username and password for the HTTP requests.
+$baseUrl = 'https://api-test.wirecard.com';
+$httpUser = '70000-APITEST-AP';
+$httpPass = 'qD2wzQ_hrc!8';
+
+// A default currency can also be provided.
+$config = new Config\Config($baseUrl, $httpUser, $httpPass, $configCollection, 'EUR');
+
+
+// ## Transaction
+
+// Create a `CreditCardTransaction` object, which contains all relevant data for the payment process.
+// The token is required as reference to the credit card data.
+$transaction = new SepaTransaction();
+$transaction->setAmount($amount);
+$transaction->setIban('DE42512308000000060004');
+
+$accountHolder = new AccountHolder('Doe');
+$accountHolder->setFirstname('Jane');
+$transaction->setAccountHolder($accountHolder);
+
+// The service is used to execute the reservation (authorization) operation itself. A response object is returned.
+$transactionService = new TransactionService($config);
+$response = $transactionService->reserve($transaction);
+
+// ## Response handling
+
+// The response from the service can be used for disambiguation.
+// In case of a successful transaction, a `SuccessResponse` object is returned.
+if ($response instanceof SuccessResponse) {
+    echo sprintf('Payment with id %s successfully completed.<br>', $response->getTransactionId());
+
+// In case of a failed transaction, a `FailureResponse` object is returned.
+} elseif ($response instanceof FailureResponse) {
+    // In our example we iterate over all errors and display them in a raw state.
+    // You should handle them based on the given severity as error, warning or information.
+    foreach ($response->getStatusCollection() as $status) {
+        /**
+         * @var $status \Wirecard\PaymentSdk\Entity\Status
+         */
+        $severity = ucfirst($status->getSeverity());
+        $code = $status->getCode();
+        $description = $status->getDescription();
+        echo sprintf('%s with code %s and message "%s" occured.<br>', $severity, $code, $description);
+    }
+}

--- a/examples/Sepa/reserve.php
+++ b/examples/Sepa/reserve.php
@@ -49,7 +49,7 @@ $transaction->setAmount($amount);
 $transaction->setIban('DE42512308000000060004');
 
 $accountHolder = new AccountHolder('Doe');
-$accountHolder->setFirstname('Jane');
+$accountHolder->setFirstName('Jane');
 $transaction->setAccountHolder($accountHolder);
 
 // The service is used to execute the reservation (authorization) operation itself. A response object is returned.

--- a/examples/Sepa/reserve.php
+++ b/examples/Sepa/reserve.php
@@ -25,7 +25,7 @@ $amount = new Money(12.59, 'EUR');
 // Since payment method may have a different merchant ID, a config collection is created.
 $configCollection = new Config\PaymentMethodConfigCollection();
 
-// Create and add a configuration object with the settings for credit card
+// Create and add a configuration object with the settings for SEPA
 $sepaMId = '4c901196-eff7-411e-82a3-5ef6b6860d64';
 $sepaKey = 'ecdf5990-0372-47cd-a55d-037dccfe9d25';
 $sepaDdConfig = new Config\PaymentMethodConfig(SepaTransaction::DIRECT_DEBIT, $sepaMId, $sepaKey);
@@ -42,8 +42,7 @@ $config = new Config\Config($baseUrl, $httpUser, $httpPass, $configCollection, '
 
 // ## Transaction
 
-// Create a `CreditCardTransaction` object, which contains all relevant data for the payment process.
-// The token is required as reference to the credit card data.
+// Create a `SepaTransaction` object, which contains all relevant data for the payment process.
 $transaction = new SepaTransaction();
 $transaction->setAmount($amount);
 $transaction->setIban($_POST['iban']);

--- a/src/Config/PaymentMethodConfig.php
+++ b/src/Config/PaymentMethodConfig.php
@@ -31,7 +31,9 @@
 
 namespace Wirecard\PaymentSdk\Config;
 
-class PaymentMethodConfig
+use Wirecard\PaymentSdk\Entity\MappableEntity;
+
+class PaymentMethodConfig implements MappableEntity
 {
     /**
      * @var string
@@ -49,6 +51,11 @@ class PaymentMethodConfig
     private $secret;
 
     /**
+     * @var array
+     */
+    private $specificProperties;
+
+    /**
      * PaymentMethodConfig constructor.
      * @param string $paymentMethodName
      * @param string $merchantAccountId
@@ -59,6 +66,7 @@ class PaymentMethodConfig
         $this->paymentMethodName = $paymentMethodName;
         $this->merchantAccountId = $merchantAccountId;
         $this->secret = $secret;
+        $this->specificProperties = [];
     }
 
     /**
@@ -83,5 +91,22 @@ class PaymentMethodConfig
     public function getSecret()
     {
         return $this->secret;
+    }
+
+    /**
+     * @param string $key
+     * @param string $value
+     */
+    public function addSpecificProperty($key, $value)
+    {
+        $this->specificProperties[$key] = $value;
+    }
+
+    /**
+     * @return array
+     */
+    public function mappedProperties()
+    {
+        return $this->specificProperties;
     }
 }

--- a/src/Entity/AccountHolder.php
+++ b/src/Entity/AccountHolder.php
@@ -32,15 +32,13 @@
 
 namespace Wirecard\PaymentSdk\Entity;
 
-use Wirecard\PaymentSdk\Transaction\Mappable;
-
 /**
  * Class Money
  * @package Wirecard\PaymentSdk\Entity
  *
  * An immutable entity representing an account holder.
  */
-class AccountHolder implements Mappable
+class AccountHolder implements MappableEntity
 {
     /**
      * @var string
@@ -71,11 +69,9 @@ class AccountHolder implements Mappable
     }
 
     /**
-     * @param string|null $operation
-     * @param string|null $parentTransactionType
      * @return array
      */
-    public function mappedProperties($operation = null, $parentTransactionType = null)
+    public function mappedProperties()
     {
         $result = [ 'last-name'=> $this->lastName ];
         if (null !== $this->firstName) {

--- a/src/Entity/AccountHolder.php
+++ b/src/Entity/AccountHolder.php
@@ -63,14 +63,6 @@ class AccountHolder implements Mappable
     }
 
     /**
-     * @return string
-     */
-    public function getLastname()
-    {
-        return $this->lastname;
-    }
-
-    /**
      * @param string $firstname
      */
     public function setFirstname($firstname)

--- a/src/Entity/AccountHolder.php
+++ b/src/Entity/AccountHolder.php
@@ -45,29 +45,29 @@ class AccountHolder implements Mappable
     /**
      * @var string
      */
-    private $lastname;
+    private $lastName;
 
     /**
      * @var string
      */
-    private $firstname;
+    private $firstName;
 
 
     /**
      * AccountHolder constructor.
-     * @param $lastname
+     * @param $lastName
      */
-    public function __construct($lastname)
+    public function __construct($lastName)
     {
-        $this->lastname = $lastname;
+        $this->lastName = $lastName;
     }
 
     /**
-     * @param string $firstname
+     * @param string $firstName
      */
-    public function setFirstname($firstname)
+    public function setFirstName($firstName)
     {
-        $this->firstname = $firstname;
+        $this->firstName = $firstName;
     }
 
     /**
@@ -77,9 +77,9 @@ class AccountHolder implements Mappable
      */
     public function mappedProperties($operation = null, $parentTransactionType = null)
     {
-        $result = [ 'last-name'=> $this->lastname ];
-        if (null !== $this->firstname) {
-            $result['first-name'] = $this->firstname;
+        $result = [ 'last-name'=> $this->lastName ];
+        if (null !== $this->firstName) {
+            $result['first-name'] = $this->firstName;
         }
         return $result;
     }

--- a/src/Entity/Mandate.php
+++ b/src/Entity/Mandate.php
@@ -67,7 +67,7 @@ class Mandate implements MappableEntity
             'mandate-id' => $this->id
         ];
 
-        if (null !== $this->signedDate){
+        if (null !== $this->signedDate) {
             $result['signed-date'] = date('Y-m-d', $this->signedDate);
         }
 

--- a/src/Entity/Mandate.php
+++ b/src/Entity/Mandate.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Shop System Plugins - Terms of Use
+ *
+ * The plugins offered are provided free of charge by Wirecard Central Eastern Europe GmbH
+ * (abbreviated to Wirecard CEE) and are explicitly not part of the Wirecard CEE range of
+ * products and services.
+ *
+ * They have been tested and approved for full functionality in the standard configuration
+ * (status on delivery) of the corresponding shop system. They are under General Public
+ * License Version 3 (GPLv3) and can be used, developed and passed on to third parties under
+ * the same terms.
+ *
+ * However, Wirecard CEE does not provide any guarantee or accept any liability for any errors
+ * occurring when used in an enhanced, customized shop system configuration.
+ *
+ * Operation in an enhanced, customized configuration is at your own risk and requires a
+ * comprehensive test phase by the user of the plugin.
+ *
+ * Customers use the plugins at their own risk. Wirecard CEE does not guarantee their full
+ * functionality neither does Wirecard CEE assume liability for any disadvantages related to
+ * the use of the plugins. Additionally, Wirecard CEE does not guarantee the full functionality
+ * for customized shop systems or installed plugins of other vendors of plugins within the same
+ * shop system.
+ *
+ * Customers are responsible for testing the plugin's functionality before starting productive
+ * operation.
+ *
+ * By installing the plugin into the shop system the customer agrees to these terms of use.
+ * Please do not use the plugin if you do not agree to these terms of use!
+ */
+
+namespace Wirecard\PaymentSdk\Entity;
+
+class Mandate implements MappableEntity
+{
+    /**
+     * @var string
+     */
+    private $id;
+
+    /**
+     * @var \DateTime
+     */
+    private $signedDate;
+
+    /**
+     * Mandate constructor.
+     * @param string $id
+     */
+    public function __construct($id)
+    {
+        $this->id = $id;
+    }
+
+    /**
+     * @param \DateTime $signedDate
+     */
+    public function setSignedDate($signedDate)
+    {
+        $this->signedDate = $signedDate;
+    }
+
+    public function mappedProperties()
+    {
+        $result = [
+            'mandate-id' => $this->id
+        ];
+
+        if (null !== $this->signedDate){
+            $result['signed-date'] = date('Y-m-d', $this->signedDate);
+        }
+
+        return $result;
+    }
+}

--- a/src/Entity/MappableEntity.php
+++ b/src/Entity/MappableEntity.php
@@ -30,14 +30,16 @@
  * Please do not use the plugin if you do not agree to these terms of use!
  */
 
-namespace Wirecard\PaymentSdk\Transaction;
+namespace Wirecard\PaymentSdk\Entity;
 
-interface Mappable
+/**
+ * Interface MappableEntity
+ * @package Wirecard\PaymentSdk\Entity
+ *
+ * Represents an entity which can be mapped
+ * => it can be included in a request to Elastic Engine.
+ */
+interface MappableEntity
 {
-    /**
-     * @param string|null $operation
-     * @param string|null $parentTransactionType
-     * @return array
-     */
-    public function mappedProperties($operation = null, $parentTransactionType = null);
+    public function mappedProperties();
 }

--- a/src/Entity/Money.php
+++ b/src/Entity/Money.php
@@ -32,15 +32,13 @@
 
 namespace Wirecard\PaymentSdk\Entity;
 
-use Wirecard\PaymentSdk\Transaction\Mappable;
-
 /**
  * Class Money
  * @package Wirecard\PaymentSdk\Entity
  *
  * An immutable entity representing a money: amount and currency.
  */
-class Money implements Mappable
+class Money implements MappableEntity
 {
     /**
      * @var float
@@ -80,11 +78,9 @@ class Money implements Mappable
     }
 
     /**
-     * @param string|null $operation
-     * @param string|null $parentTransactionType
      * @return array
      */
-    public function mappedProperties($operation = null, $parentTransactionType = null)
+    public function mappedProperties()
     {
         return [
             'currency' => $this->currency,

--- a/src/Mapper/RequestMapper.php
+++ b/src/Mapper/RequestMapper.php
@@ -77,9 +77,15 @@ class RequestMapper
             'request-id' => $requestId
         ];
 
+        $paymentMethodConfig = $this->config->get(
+            $transaction->getConfigKey($operation, $parentTransactionType)
+        );
+        $paymentMethodConfigProperties = $paymentMethodConfig->mappedProperties();
+
         $allProperties = array_merge(
             $commonProperties,
-            $transaction->mappedProperties($operation, $parentTransactionType)
+            $transaction->mappedProperties($operation, $parentTransactionType),
+            $paymentMethodConfigProperties
         );
 
         $allProperties['merchant-account-id']['value'] = $this->config->get($transaction->getConfigKey())

--- a/src/Transaction/CreditCardTransaction.php
+++ b/src/Transaction/CreditCardTransaction.php
@@ -63,12 +63,12 @@ class CreditCardTransaction extends Transaction
     }
 
     /**
-     * @param string|null $operation
-     * @param string|null $parentTransactionType
+     * @param string $operation
+     * @param string $parentTransactionType
      * @throws MandatoryFieldMissingException|UnsupportedOperationException
      * @return array
      */
-    public function mappedProperties($operation = null, $parentTransactionType = null)
+    protected function mappedSpecificProperties($operation, $parentTransactionType)
     {
         if ($this->tokenId === null && ($this->parentTransactionId === null && get_class($this) === self::class)) {
             throw new MandatoryFieldMissingException(
@@ -76,7 +76,6 @@ class CreditCardTransaction extends Transaction
             );
         }
 
-        $result = parent::mappedProperties($operation, $parentTransactionType);
         $result[self::PARAM_TRANSACTION_TYPE] = $this->retrieveTransactionType($operation, $parentTransactionType);
 
         if (null !== $this->tokenId) {

--- a/src/Transaction/PayPalTransaction.php
+++ b/src/Transaction/PayPalTransaction.php
@@ -57,20 +57,17 @@ class PayPalTransaction extends Transaction
     }
 
     /**
-     * @param string|null $operation
-     * @param string|null $parentTransactionType
+     * @param string $operation
+     * @param string $parentTransactionType
      * @return array
      */
-    public function mappedProperties($operation = null, $parentTransactionType = null)
+    protected function mappedSpecificProperties($operation, $parentTransactionType)
     {
-
-        $specificProperties = [
+        return [
             self::PARAM_TRANSACTION_TYPE => $this->retrieveTransactionType($operation),
             'cancel-redirect-url' => $this->redirect->getCancelUrl(),
             'success-redirect-url' => $this->redirect->getSuccessUrl()
         ];
-
-        return array_merge(parent::mappedProperties($operation, $parentTransactionType), $specificProperties);
     }
 
     /**

--- a/src/Transaction/SepaTransaction.php
+++ b/src/Transaction/SepaTransaction.php
@@ -69,6 +69,7 @@ class SepaTransaction extends Transaction
     /**
      * @param null $operation
      * @param null $parentTransactionType
+     * @return array
      */
     public function mappedProperties($operation = null, $parentTransactionType = null)
     {

--- a/src/Transaction/SepaTransaction.php
+++ b/src/Transaction/SepaTransaction.php
@@ -32,6 +32,7 @@
 
 namespace Wirecard\PaymentSdk\Transaction;
 
+use Wirecard\PaymentSdk\Entity\Mandate;
 use Wirecard\PaymentSdk\Exception\UnsupportedOperationException;
 
 class SepaTransaction extends Transaction
@@ -51,6 +52,11 @@ class SepaTransaction extends Transaction
     private $bic;
 
     /**
+     * @var Mandate
+     */
+    private $mandate;
+
+    /**
      * @param string $iban
      */
     public function setIban($iban)
@@ -64,6 +70,14 @@ class SepaTransaction extends Transaction
     public function setBic($bic)
     {
         $this->bic = $bic;
+    }
+
+    /**
+     * @param Mandate $mandate
+     */
+    public function setMandate($mandate)
+    {
+        $this->mandate = $mandate;
     }
 
     /**

--- a/src/Transaction/SepaTransaction.php
+++ b/src/Transaction/SepaTransaction.php
@@ -75,11 +75,14 @@ class SepaTransaction extends Transaction
     {
         $result = parent::mappedProperties($operation, $parentTransactionType);
         $result[self::PARAM_TRANSACTION_TYPE] = $this->retrieveTransactionType($operation, $parentTransactionType);
-        $result['bank-account'] = [
-            'iban' => $this->iban
-        ];
-        if (null !== $this->bic) {
-            $result['bank-account']['bic'] = $this->bic;
+
+        if (null !== $this->iban) {
+            $result['bank-account'] = [
+                'iban' => $this->iban
+            ];
+            if (null !== $this->bic) {
+                $result['bank-account']['bic'] = $this->bic;
+            }
         }
 
         return $result;

--- a/src/Transaction/SepaTransaction.php
+++ b/src/Transaction/SepaTransaction.php
@@ -36,11 +36,9 @@ use Wirecard\PaymentSdk\Exception\UnsupportedOperationException;
 
 class SepaTransaction extends Transaction
 {
-    const DIRECT_DEBIT = 'SEPA Direct Debit';
+    const DIRECT_DEBIT = 'sepadirectdebit';
 
-    const CREDIT_TRANSFER = 'SEPA Credit Transfer';
-
-    const NAME = 'sepadirectdebit';
+    const CREDIT_TRANSFER = 'sepacredit';
 
     /**
      * @var string
@@ -87,8 +85,17 @@ class SepaTransaction extends Transaction
         return $result;
     }
 
-    public function getConfigKey($operation = null)
+    public function getConfigKey($operation = null, $parentTransactionType = null)
     {
+        return $this->retrievePaymentMethodName($operation, $parentTransactionType);
+    }
+
+    public function retrievePaymentMethodName($operation = null, $parentTransactionType = null)
+    {
+        if (Operation::CREDIT === $operation || Operation::CREDIT == $parentTransactionType) {
+            return self::CREDIT_TRANSFER;
+        }
+
         return self::DIRECT_DEBIT;
     }
 

--- a/src/Transaction/SepaTransaction.php
+++ b/src/Transaction/SepaTransaction.php
@@ -30,65 +30,62 @@
  * Please do not use the plugin if you do not agree to these terms of use!
  */
 
-namespace Wirecard\PaymentSdk\Entity;
+namespace Wirecard\PaymentSdk\Transaction;
 
-use Wirecard\PaymentSdk\Transaction\Mappable;
-
-/**
- * Class Money
- * @package Wirecard\PaymentSdk\Entity
- *
- * An immutable entity representing an account holder.
- */
-class AccountHolder implements Mappable
+class SepaTransaction extends Transaction
 {
-    /**
-     * @var string
-     */
-    private $lastname;
+    const DIRECT_DEBIT = 'SEPA Direct Debit';
+
+    const CREDIT_TRANSFER = 'SEPA Credit Transfer';
+
+    const NAME = 'sepadirectdebit';
 
     /**
      * @var string
      */
-    private $firstname;
-
+    private $iban;
 
     /**
-     * AccountHolder constructor.
-     * @param $lastname
+     * @var string
      */
-    public function __construct($lastname)
+    private $bic;
+
+    /**
+     * @param string $iban
+     */
+    public function setIban($iban)
     {
-        $this->lastname = $lastname;
+        $this->iban = $iban;
     }
 
     /**
-     * @return string
+     * @param string $bic
      */
-    public function getLastname()
+    public function setBic($bic)
     {
-        return $this->lastname;
+        $this->bic = $bic;
     }
 
     /**
-     * @param string $firstname
-     */
-    public function setFirstname($firstname)
-    {
-        $this->firstname = $firstname;
-    }
-
-    /**
-     * @param string|null $operation
-     * @param string|null $parentTransactionType
-     * @return array
+     * @param null $operation
+     * @param null $parentTransactionType
      */
     public function mappedProperties($operation = null, $parentTransactionType = null)
     {
-        $result = [ 'last-name'=> $this->lastname ];
-        if (null !== $this->firstname) {
-            $result['first-name'] = $this->firstname;
+        $result = parent::mappedProperties($operation, $parentTransactionType);
+        $result[self::PARAM_TRANSACTION_TYPE] = 'authorization';
+        $result['bank-account'] = [
+          'iban' => $this->iban
+        ];
+        if (null !== $this->bic) {
+            $result['bank-account']['bic'] = $this->bic;
         }
+
         return $result;
+    }
+
+    public function getConfigKey($operation = null)
+    {
+        return self::DIRECT_DEBIT;
     }
 }

--- a/src/Transaction/SepaTransaction.php
+++ b/src/Transaction/SepaTransaction.php
@@ -67,14 +67,15 @@ class SepaTransaction extends Transaction
     }
 
     /**
-     * @param null $operation
-     * @param null $parentTransactionType
+     * @param string $operation
+     * @param string $parentTransactionType
      * @return array
      */
-    public function mappedProperties($operation = null, $parentTransactionType = null)
+    protected function mappedSpecificProperties($operation, $parentTransactionType)
     {
-        $result = parent::mappedProperties($operation, $parentTransactionType);
-        $result[self::PARAM_TRANSACTION_TYPE] = $this->retrieveTransactionType($operation, $parentTransactionType);
+        $result = [
+            self::PARAM_TRANSACTION_TYPE => $this->retrieveTransactionType($operation, $parentTransactionType)
+        ];
 
         if (null !== $this->iban) {
             $result['bank-account'] = [

--- a/src/Transaction/SepaTransaction.php
+++ b/src/Transaction/SepaTransaction.php
@@ -100,6 +100,10 @@ class SepaTransaction extends Transaction
             }
         }
 
+        if (null !== $this->mandate) {
+            $result['mandate'] = $this->mandate->mappedProperties();
+        }
+
         return $result;
     }
 

--- a/src/Transaction/ThreeDCreditCardTransaction.php
+++ b/src/Transaction/ThreeDCreditCardTransaction.php
@@ -91,14 +91,14 @@ class ThreeDCreditCardTransaction extends CreditCardTransaction
     }
 
     /**
-     * @param string|null $operation
-     * @param string|null $parentTransactionType
+     * @param string $operation
+     * @param string $parentTransactionType
      * @throws MandatoryFieldMissingException|UnsupportedOperationException
      * @return array
      */
-    public function mappedProperties($operation = null, $parentTransactionType = null)
+    protected function mappedSpecificProperties($operation, $parentTransactionType)
     {
-        $result = parent::mappedProperties($operation, $parentTransactionType);
+        $result = parent::mappedSpecificProperties($operation, $parentTransactionType);
 
         if (null !== $this->paRes) {
             $result['three-d'] = [

--- a/src/Transaction/Transaction.php
+++ b/src/Transaction/Transaction.php
@@ -126,7 +126,7 @@ abstract class Transaction
     }
 
     /**
-     * @param string|null $operation
+     * @param string $operation
      * @param string|null $parentTransactionType
      * @return array
      *
@@ -134,7 +134,7 @@ abstract class Transaction
      *  - the common properties are mapped here,
      *  - an abstract operation is defined for the payment type specific properties.
      */
-    public function mappedProperties($operation = null, $parentTransactionType = null)
+    public function mappedProperties($operation, $parentTransactionType = null)
     {
         $result = ['payment-methods' => ['payment-method' => [['name' => $this->retrievePaymentMethodName()]]]];
 

--- a/src/Transaction/Transaction.php
+++ b/src/Transaction/Transaction.php
@@ -132,7 +132,7 @@ abstract class Transaction implements Mappable
      */
     public function mappedProperties($operation = null, $parentTransactionType = null)
     {
-        $result = ['payment-methods' => ['payment-method' => [['name' => $this::NAME]]]];
+        $result = ['payment-methods' => ['payment-method' => [['name' => $this->retrievePaymentMethodName()]]]];
 
         if ($this->amount) {
             $result['requested-amount'] = $this->amount->mappedProperties();
@@ -168,8 +168,16 @@ abstract class Transaction implements Mappable
      * @param string|null
      * @return string
      */
-    public function getConfigKey($operation = null)
+    public function getConfigKey($operation = null, $parentTransactionType = null)
     {
         return get_class($this);
+    }
+
+    /**
+     * @return string
+     */
+    public function retrievePaymentMethodName($operation = null, $parentTransactionType = null)
+    {
+        return $this::NAME;
     }
 }

--- a/src/Transaction/Transaction.php
+++ b/src/Transaction/Transaction.php
@@ -39,7 +39,7 @@ use Wirecard\PaymentSdk\Entity\Money;
  * Interface Transaction
  * @package Wirecard\PaymentSdk\Transaction
  */
-abstract class Transaction implements Mappable
+abstract class Transaction
 {
     const PARAM_PAYMENT = 'payment';
     const PARAM_TRANSACTION_TYPE = 'transaction-type';
@@ -129,6 +129,11 @@ abstract class Transaction implements Mappable
      * @param string|null $operation
      * @param string|null $parentTransactionType
      * @return array
+     *
+     * Contains the mapping of the transaction properties.
+     * Subclasses should use the logic below
+     * and add the mapping of their specific properties.
+     * The mapping of the subclass-specific properties often depends on the operation and the parentTransactionType.
      */
     public function mappedProperties($operation = null, $parentTransactionType = null)
     {

--- a/src/Transaction/Transaction.php
+++ b/src/Transaction/Transaction.php
@@ -130,10 +130,9 @@ abstract class Transaction
      * @param string|null $parentTransactionType
      * @return array
      *
-     * Contains the mapping of the transaction properties.
-     * Subclasses should use the logic below
-     * and add the mapping of their specific properties.
-     * The mapping of the subclass-specific properties often depends on the operation and the parentTransactionType.
+     * A template method for the mapping of the transaction properties:
+     *  - the common properties are mapped here,
+     *  - an abstract operation is defined for the payment type specific properties.
      */
     public function mappedProperties($operation = null, $parentTransactionType = null)
     {
@@ -166,8 +165,15 @@ abstract class Transaction
             $result['consumer-id'] = $this->consumerId;
         }
 
-        return $result;
+        return array_merge($result, $this->mappedSpecificProperties($operation, $parentTransactionType));
     }
+
+    /**
+     * @param string $operation
+     * @param string $parentTransactionType
+     * @return array
+     */
+    abstract protected function mappedSpecificProperties($operation, $parentTransactionType);
 
     /**
      * @param string|null

--- a/src/TransactionService.php
+++ b/src/TransactionService.php
@@ -267,7 +267,6 @@ class TransactionService
         return $this->process($transaction, Operation::CREDIT);
     }
 
-
     /**
      * @return LoggerInterface
      */

--- a/test/Config/PaymentMethodConfigUTest.php
+++ b/test/Config/PaymentMethodConfigUTest.php
@@ -65,4 +65,33 @@ class PaymentMethodConfigUTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEquals(self::SECRET, $this->instance->getSecret());
     }
+
+    public function testMappedPropertiesWithoutSpecificProperties()
+    {
+        $this->assertEquals([], $this->instance->mappedProperties());
+    }
+
+    public function testMappedPropertiesWith1SpecificProperty()
+    {
+        $this->instance->addSpecificProperty('creditor-id', 'anything');
+
+        $this->assertEquals(
+            [ 'creditor-id' => 'anything' ],
+            $this->instance->mappedProperties()
+        );
+    }
+
+    public function testMappedPropertiesWith2SpecificProperties()
+    {
+        $this->instance->addSpecificProperty('creditor-id', 'anything');
+        $this->instance->addSpecificProperty('dummy-id', 'bla');
+
+        $this->assertEquals(
+            [
+                'creditor-id' => 'anything',
+                'dummy-id' => 'bla'
+            ],
+            $this->instance->mappedProperties()
+        );
+    }
 }

--- a/test/Entity/AccountHolderUTest.php
+++ b/test/Entity/AccountHolderUTest.php
@@ -48,11 +48,6 @@ class AccountHolderUTest extends \PHPUnit_Framework_TestCase
         $this->accountholder = new AccountHolder(self::LASTNAME);
     }
 
-    public function testGetLastname()
-    {
-        $this->assertEquals(self::LASTNAME, $this->accountholder->getLastname());
-    }
-
     public function testGetMappedProperties()
     {
         $this->assertEquals([ 'last-name' => self::LASTNAME ], $this->accountholder->mappedProperties());

--- a/test/Entity/AccountHolderUTest.php
+++ b/test/Entity/AccountHolderUTest.php
@@ -41,15 +41,29 @@ class AccountHolderUTest extends \PHPUnit_Framework_TestCase
     /**
      * @var AccountHolder
      */
-    private $accountholder;
+    private $accountHolder;
 
     public function setUp()
     {
-        $this->accountholder = new AccountHolder(self::LASTNAME);
+        $this->accountHolder = new AccountHolder(self::LASTNAME);
     }
 
-    public function testGetMappedProperties()
+    public function testGetMappedPropertiesOnlyLastName()
     {
-        $this->assertEquals([ 'last-name' => self::LASTNAME ], $this->accountholder->mappedProperties());
+        $this->assertEquals([ 'last-name' => self::LASTNAME ], $this->accountHolder->mappedProperties());
+    }
+
+    public function testGetMappedPropertiesLastAndFirstName()
+    {
+        $firstName = 'Jane';
+        $this->accountHolder->setFirstName($firstName);
+
+        $this->assertEquals(
+            [
+                'last-name' => self::LASTNAME,
+                'first-name' => $firstName
+            ],
+            $this->accountHolder->mappedProperties()
+        );
     }
 }

--- a/test/Entity/MandateUTest.php
+++ b/test/Entity/MandateUTest.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Shop System Plugins - Terms of Use
+ *
+ * The plugins offered are provided free of charge by Wirecard Central Eastern Europe GmbH
+ * (abbreviated to Wirecard CEE) and are explicitly not part of the Wirecard CEE range of
+ * products and services.
+ *
+ * They have been tested and approved for full functionality in the standard configuration
+ * (status on delivery) of the corresponding shop system. They are under General Public
+ * License Version 3 (GPLv3) and can be used, developed and passed on to third parties under
+ * the same terms.
+ *
+ * However, Wirecard CEE does not provide any guarantee or accept any liability for any errors
+ * occurring when used in an enhanced, customized shop system configuration.
+ *
+ * Operation in an enhanced, customized configuration is at your own risk and requires a
+ * comprehensive test phase by the user of the plugin.
+ *
+ * Customers use the plugins at their own risk. Wirecard CEE does not guarantee their full
+ * functionality neither does Wirecard CEE assume liability for any disadvantages related to
+ * the use of the plugins. Additionally, Wirecard CEE does not guarantee the full functionality
+ * for customized shop systems or installed plugins of other vendors of plugins within the same
+ * shop system.
+ *
+ * Customers are responsible for testing the plugin's functionality before starting productive
+ * operation.
+ *
+ * By installing the plugin into the shop system the customer agrees to these terms of use.
+ * Please do not use the plugin if you do not agree to these terms of use!
+ */
+
+namespace WirecardTest\PaymentSdk\Entity;
+
+use Wirecard\PaymentSdk\Entity\Mandate;
+
+class MandateUTest extends \PHPUnit_Framework_TestCase
+{
+    const ID = '345';
+
+    /**
+     * @var Mandate
+     */
+    private $mandate;
+
+    public function setUp()
+    {
+        $this->mandate = new Mandate(self::ID);
+    }
+
+    public function testMappedPropertiesWithoutSignedDate()
+    {
+        $expectedResult = [
+            'mandate-id' => self::ID
+        ];
+
+        $result = $this->mandate->mappedProperties();
+
+        $this->assertEquals($expectedResult, $result);
+    }
+
+    public function testMappedPropertiesWithSignedDate()
+    {
+        $dateAsStr = '2017-03-24';
+        $signedDate = strtotime($dateAsStr);
+        $this->mandate->setSignedDate($signedDate);
+
+        $expectedResult = [
+            'mandate-id' => self::ID,
+            'signed-date' => $dateAsStr
+        ];
+
+        $result = $this->mandate->mappedProperties();
+
+        $this->assertEquals($expectedResult, $result);
+    }
+}

--- a/test/Mapper/RequestMapperUTest.php
+++ b/test/Mapper/RequestMapperUTest.php
@@ -55,6 +55,7 @@ class RequestMapperUTest extends \PHPUnit_Framework_TestCase
     {
         $paymentMethodConfig = $this->createMock(PaymentMethodConfig::class);
         $paymentMethodConfig->method('getMerchantAccountId')->willReturn(self::MAID);
+        $paymentMethodConfig->method('mappedProperties')->willReturn([]);
         $paymentMethodConfigs = $this->createMock(PaymentMethodConfigCollection::class);
         $paymentMethodConfigs->method('get')->willReturn($paymentMethodConfig);
 
@@ -89,6 +90,7 @@ class RequestMapperUTest extends \PHPUnit_Framework_TestCase
         $_SERVER['REMOTE_ADDR'] = 'test IP';
         $paymentMethodConfig = $this->createMock(PaymentMethodConfig::class);
         $paymentMethodConfig->method('getMerchantAccountId')->willReturn(self::MAID);
+        $paymentMethodConfig->method('mappedProperties')->willReturn([]);
         $paymentMethodConfigs = $this->createMock(PaymentMethodConfigCollection::class);
         $paymentMethodConfigs->method('get')->willReturn($paymentMethodConfig);
 
@@ -122,6 +124,7 @@ class RequestMapperUTest extends \PHPUnit_Framework_TestCase
         $_SERVER['REMOTE_ADDR'] = 'test IP';
         $paymentMethodConfig = $this->createMock(PaymentMethodConfig::class);
         $paymentMethodConfig->method('getMerchantAccountId')->willReturn(self::MAID);
+        $paymentMethodConfig->method('mappedProperties')->willReturn([]);
         $paymentMethodConfigs = $this->createMock(PaymentMethodConfigCollection::class);
         $paymentMethodConfigs->method('get')->willReturn($paymentMethodConfig);
 
@@ -172,6 +175,7 @@ class RequestMapperUTest extends \PHPUnit_Framework_TestCase
         $_SERVER['REMOTE_ADDR'] = 'test IP';
         $paymentMethodConfig = $this->createMock(PaymentMethodConfig::class);
         $paymentMethodConfig->method('getMerchantAccountId')->willReturn(self::MAID);
+        $paymentMethodConfig->method('mappedProperties')->willReturn([]);
         $paymentMethodConfigs = $this->createMock(PaymentMethodConfigCollection::class);
         $paymentMethodConfigs->method('get')->willReturn($paymentMethodConfig);
 
@@ -235,6 +239,7 @@ class RequestMapperUTest extends \PHPUnit_Framework_TestCase
         $_SERVER['REMOTE_ADDR'] = 'test IP';
         $paymentMethodConfig = $this->createMock(PaymentMethodConfig::class);
         $paymentMethodConfig->method('getMerchantAccountId')->willReturn(self::MAID);
+        $paymentMethodConfig->method('mappedProperties')->willReturn([]);
         $paymentMethodConfigs = $this->createMock(PaymentMethodConfigCollection::class);
         $paymentMethodConfigs->method('get')->willReturn($paymentMethodConfig);
 
@@ -275,6 +280,7 @@ class RequestMapperUTest extends \PHPUnit_Framework_TestCase
         $_SERVER['REMOTE_ADDR'] = 'test IP';
         $paymentMethodConfig = $this->createMock(PaymentMethodConfig::class);
         $paymentMethodConfig->method('getMerchantAccountId')->willReturn(self::MAID);
+        $paymentMethodConfig->method('mappedProperties')->willReturn([]);
         $paymentMethodConfigs = $this->createMock(PaymentMethodConfigCollection::class);
         $paymentMethodConfigs->method('get')->willReturn($paymentMethodConfig);
 
@@ -324,6 +330,7 @@ class RequestMapperUTest extends \PHPUnit_Framework_TestCase
     {
         $paymentMethodConfig = $this->createMock(PaymentMethodConfig::class);
         $paymentMethodConfig->method('getMerchantAccountId')->willReturn(self::MAID);
+        $paymentMethodConfig->method('mappedProperties')->willReturn([]);
         $paymentMethodConfigs = $this->createMock(PaymentMethodConfigCollection::class);
         $paymentMethodConfigs->method('get')->willReturn($paymentMethodConfig);
 
@@ -374,6 +381,7 @@ class RequestMapperUTest extends \PHPUnit_Framework_TestCase
     {
         $paymentMethodConfig = $this->createMock(PaymentMethodConfig::class);
         $paymentMethodConfig->method('getMerchantAccountId')->willReturn(self::MAID);
+        $paymentMethodConfig->method('mappedProperties')->willReturn([]);
         $paymentMethodConfigs = $this->createMock(PaymentMethodConfigCollection::class);
         $paymentMethodConfigs->method('get')->willReturn($paymentMethodConfig);
 
@@ -428,6 +436,7 @@ class RequestMapperUTest extends \PHPUnit_Framework_TestCase
     {
         $paymentMethodConfig = $this->createMock(PaymentMethodConfig::class);
         $paymentMethodConfig->method('getMerchantAccountId')->willReturn(self::MAID);
+        $paymentMethodConfig->method('mappedProperties')->willReturn([]);
         $paymentMethodConfigs = $this->createMock(PaymentMethodConfigCollection::class);
         $paymentMethodConfigs->method('get')->willReturn($paymentMethodConfig);
 
@@ -458,6 +467,7 @@ class RequestMapperUTest extends \PHPUnit_Framework_TestCase
     {
         $paymentMethodConfig = $this->createMock(PaymentMethodConfig::class);
         $paymentMethodConfig->method('getMerchantAccountId')->willReturn(self::MAID);
+        $paymentMethodConfig->method('mappedProperties')->willReturn([]);
         $paymentMethodConfigs = $this->createMock(PaymentMethodConfigCollection::class);
         $paymentMethodConfigs->method('get')->willReturn($paymentMethodConfig);
 
@@ -475,6 +485,7 @@ class RequestMapperUTest extends \PHPUnit_Framework_TestCase
     {
         $paymentMethodConfig = $this->createMock(PaymentMethodConfig::class);
         $paymentMethodConfig->method('getMerchantAccountId')->willReturn(self::MAID);
+        $paymentMethodConfig->method('mappedProperties')->willReturn([]);
         $paymentMethodConfigs = $this->createMock(PaymentMethodConfigCollection::class);
         $paymentMethodConfigs->method('get')->willReturn($paymentMethodConfig);
 

--- a/test/Transaction/SepaTransactionUTest.php
+++ b/test/Transaction/SepaTransactionUTest.php
@@ -34,7 +34,6 @@ namespace WirecardTest\PaymentSdk\Transaction;
 
 use Wirecard\PaymentSdk\Entity\AccountHolder;
 use Wirecard\PaymentSdk\Entity\Money;
-use Wirecard\PaymentSdk\Exception\UnsupportedOperationException;
 use Wirecard\PaymentSdk\Transaction\Operation;
 use Wirecard\PaymentSdk\Transaction\SepaTransaction;
 

--- a/test/Transaction/SepaTransactionUTest.php
+++ b/test/Transaction/SepaTransactionUTest.php
@@ -92,6 +92,8 @@ class SepaTransactionUTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expectedResult, $result);
     }
 
+
+
     /**
      * @return array
      */
@@ -119,5 +121,17 @@ class SepaTransactionUTest extends \PHPUnit_Framework_TestCase
             ]
         ];
         return $expectedResult;
+    }
+
+    public function testRetrievePaymentMethodNamePay()
+    {
+        $this->assertEquals(SepaTransaction::DIRECT_DEBIT, $this->tx->retrievePaymentMethodName(Operation::PAY));
+        $this->assertEquals(SepaTransaction::DIRECT_DEBIT, $this->tx->getConfigKey(Operation::PAY));
+    }
+
+    public function testRetrievePaymentMethodNameCredit()
+    {
+        $this->assertEquals(SepaTransaction::CREDIT_TRANSFER, $this->tx->retrievePaymentMethodName(Operation::CREDIT));
+        $this->assertEquals(SepaTransaction::CREDIT_TRANSFER, $this->tx->getConfigKey(Operation::CREDIT));
     }
 }

--- a/test/Transaction/SepaTransactionUTest.php
+++ b/test/Transaction/SepaTransactionUTest.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * Shop System Plugins - Terms of Use
+ *
+ * The plugins offered are provided free of charge by Wirecard Central Eastern Europe GmbH
+ * (abbreviated to Wirecard CEE) and are explicitly not part of the Wirecard CEE range of
+ * products and services.
+ *
+ * They have been tested and approved for full functionality in the standard configuration
+ * (status on delivery) of the corresponding shop system. They are under General Public
+ * License Version 3 (GPLv3) and can be used, developed and passed on to third parties under
+ * the same terms.
+ *
+ * However, Wirecard CEE does not provide any guarantee or accept any liability for any errors
+ * occurring when used in an enhanced, customized shop system configuration.
+ *
+ * Operation in an enhanced, customized configuration is at your own risk and requires a
+ * comprehensive test phase by the user of the plugin.
+ *
+ * Customers use the plugins at their own risk. Wirecard CEE does not guarantee their full
+ * functionality neither does Wirecard CEE assume liability for any disadvantages related to
+ * the use of the plugins. Additionally, Wirecard CEE does not guarantee the full functionality
+ * for customized shop systems or installed plugins of other vendors of plugins within the same
+ * shop system.
+ *
+ * Customers are responsible for testing the plugin's functionality before starting productive
+ * operation.
+ *
+ * By installing the plugin into the shop system the customer agrees to these terms of use.
+ * Please do not use the plugin if you do not agree to these terms of use!
+ */
+
+namespace WirecardTest\PaymentSdk\Transaction;
+
+use Wirecard\PaymentSdk\Entity\AccountHolder;
+use Wirecard\PaymentSdk\Entity\Money;
+use Wirecard\PaymentSdk\Transaction\Operation;
+use Wirecard\PaymentSdk\Transaction\SepaTransaction;
+
+class SepaTransactionUTest extends \PHPUnit_Framework_TestCase
+{
+    const IBAN = 'DE42512308000000060004';
+    const LAST_NAME = 'Doe';
+    const FIRST_NAME = 'Jane';
+
+    /**
+     * @var SepaTransaction
+     */
+    private $tx;
+
+    /**
+     * @var Money
+     */
+    private $amount;
+
+    /**
+     * @var AccountHolder
+     */
+    private $accountHolder;
+
+    public function setUp()
+    {
+        $this->amount = new Money(55.5, 'EUR');
+        $this->accountHolder = new AccountHolder(self::LAST_NAME);
+        $this->accountHolder->setFirstName(self::FIRST_NAME);
+
+        $this->tx = new SepaTransaction();
+        $this->tx->setAmount($this->amount);
+        $this->tx->setIban(self::IBAN);
+        $this->tx->setAccountHolder($this->accountHolder);
+    }
+
+    public function testMappedPropertiesReserveIbanOnly()
+    {
+        $expectedResult = $this->getExpectedResultIbanOnly();
+
+        $result = $this->tx->mappedProperties(Operation::RESERVE, null);
+
+        $this->assertEquals($expectedResult, $result);
+    }
+
+    public function testMappedPropertiesReserveIbanAndBic()
+    {
+        $bic = '42B';
+        $this->tx->setBic($bic);
+
+        $expectedResult = $this->getExpectedResultIbanOnly();
+        $expectedResult['bank-account']['bic'] = $bic;
+
+        $result = $this->tx->mappedProperties(Operation::RESERVE, null);
+
+        $this->assertEquals($expectedResult, $result);
+    }
+
+    /**
+     * @return array
+     */
+    private function getExpectedResultIbanOnly()
+    {
+        $expectedResult = [
+            'transaction-type' => 'authorization',
+            'requested-amount' => [
+                'currency' => 'EUR',
+                'value' => '55.5'
+            ],
+            'account-holder' => [
+                'last-name' => self::LAST_NAME,
+                'first-name' => self::FIRST_NAME
+            ],
+            'payment-methods' => [
+                'payment-method' => [
+                    0 => [
+                        'name' => 'sepadirectdebit'
+                    ]
+                ]
+            ],
+            'bank-account' => [
+                'iban' => self::IBAN
+            ]
+        ];
+        return $expectedResult;
+    }
+}

--- a/test/Transaction/TransactionUTest.php
+++ b/test/Transaction/TransactionUTest.php
@@ -46,6 +46,7 @@ class TransactionUTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->tx = $this->getMockForAbstractClass(Transaction::class);
+        $this->tx->method('mappedSpecificProperties')->willReturn([]);
     }
 
     public function testMappingForConsumerId()

--- a/test/TransactionServiceUTest.php
+++ b/test/TransactionServiceUTest.php
@@ -67,6 +67,7 @@ class TransactionServiceUTest extends \PHPUnit_Framework_TestCase
     {
         $paymentMethodConfig = $this->createMock(PaymentMethodConfig::class);
         $paymentMethodConfig->method('getMerchantAccountId')->willReturn(self::MAID);
+        $paymentMethodConfig->method('mappedProperties')->willReturn([]);
 
         $this->config = $this->createMock('\Wirecard\PaymentSdk\Config\Config');
         $this->config->method('getHttpUser')->willReturn('abc123');


### PR DESCRIPTION
Implemented the operation pay (pending-debit) for SEPA.
 - introduced entity Mandate
 - PaymentMethodConfig: added specific properties so that we can configure creditor ID for SEPA

Example includes:
 - IBAN only
 - IBAN & BIC

Questions:  
PaymentMethodConfig contains a method addSpecificProperty(string, string) at the moment.  
Another possibility would be: addSpecificProperties(array)
