### PR TITLE
Mappable split

### DIFF
--- a/src/Entity/AccountHolder.php
+++ b/src/Entity/AccountHolder.php
@@ -32,15 +32,13 @@
 
 namespace Wirecard\PaymentSdk\Entity;
 
-use Wirecard\PaymentSdk\Transaction\Mappable;
-
 /**
  * Class Money
  * @package Wirecard\PaymentSdk\Entity
  *
  * An immutable entity representing an account holder.
  */
-class AccountHolder implements Mappable
+class AccountHolder implements MappableEntity
 {
     /**
      * @var string
@@ -71,11 +69,9 @@ class AccountHolder implements Mappable
     }
 
     /**
-     * @param string|null $operation
-     * @param string|null $parentTransactionType
      * @return array
      */
-    public function mappedProperties($operation = null, $parentTransactionType = null)
+    public function mappedProperties()
     {
         $result = [ 'last-name'=> $this->lastName ];
         if (null !== $this->firstName) {

--- a/src/Entity/MappableEntity.php
+++ b/src/Entity/MappableEntity.php
@@ -41,5 +41,8 @@ namespace Wirecard\PaymentSdk\Entity;
  */
 interface MappableEntity
 {
+    /**
+     * @return array
+     */
     public function mappedProperties();
 }

--- a/src/Entity/MappableEntity.php
+++ b/src/Entity/MappableEntity.php
@@ -30,14 +30,16 @@
  * Please do not use the plugin if you do not agree to these terms of use!
  */
 
-namespace Wirecard\PaymentSdk\Transaction;
+namespace Wirecard\PaymentSdk\Entity;
 
-interface Mappable
+/**
+ * Interface MappableEntity
+ * @package Wirecard\PaymentSdk\Entity
+ *
+ * Represents an entity which can be mapped
+ * => it can be included in a request to Elastic Engine.
+ */
+interface MappableEntity
 {
-    /**
-     * @param string|null $operation
-     * @param string|null $parentTransactionType
-     * @return array
-     */
-    public function mappedProperties($operation = null, $parentTransactionType = null);
+    public function mappedProperties();
 }

--- a/src/Entity/Money.php
+++ b/src/Entity/Money.php
@@ -32,15 +32,13 @@
 
 namespace Wirecard\PaymentSdk\Entity;
 
-use Wirecard\PaymentSdk\Transaction\Mappable;
-
 /**
  * Class Money
  * @package Wirecard\PaymentSdk\Entity
  *
  * An immutable entity representing a money: amount and currency.
  */
-class Money implements Mappable
+class Money implements MappableEntity
 {
     /**
      * @var float
@@ -80,11 +78,9 @@ class Money implements Mappable
     }
 
     /**
-     * @param string|null $operation
-     * @param string|null $parentTransactionType
      * @return array
      */
-    public function mappedProperties($operation = null, $parentTransactionType = null)
+    public function mappedProperties()
     {
         return [
             'currency' => $this->currency,

--- a/src/Transaction/CreditCardTransaction.php
+++ b/src/Transaction/CreditCardTransaction.php
@@ -63,12 +63,12 @@ class CreditCardTransaction extends Transaction
     }
 
     /**
-     * @param string|null $operation
-     * @param string|null $parentTransactionType
+     * @param string $operation
+     * @param string $parentTransactionType
      * @throws MandatoryFieldMissingException|UnsupportedOperationException
      * @return array
      */
-    public function mappedProperties($operation = null, $parentTransactionType = null)
+    protected function mappedSpecificProperties($operation, $parentTransactionType)
     {
         if ($this->tokenId === null && ($this->parentTransactionId === null && get_class($this) === self::class)) {
             throw new MandatoryFieldMissingException(
@@ -76,7 +76,6 @@ class CreditCardTransaction extends Transaction
             );
         }
 
-        $result = parent::mappedProperties($operation, $parentTransactionType);
         $result[self::PARAM_TRANSACTION_TYPE] = $this->retrieveTransactionType($operation, $parentTransactionType);
 
         if (null !== $this->tokenId) {

--- a/src/Transaction/PayPalTransaction.php
+++ b/src/Transaction/PayPalTransaction.php
@@ -57,20 +57,17 @@ class PayPalTransaction extends Transaction
     }
 
     /**
-     * @param string|null $operation
-     * @param string|null $parentTransactionType
+     * @param string $operation
+     * @param string $parentTransactionType
      * @return array
      */
-    public function mappedProperties($operation = null, $parentTransactionType = null)
+    protected function mappedSpecificProperties($operation, $parentTransactionType)
     {
-
-        $specificProperties = [
+        return [
             self::PARAM_TRANSACTION_TYPE => $this->retrieveTransactionType($operation),
             'cancel-redirect-url' => $this->redirect->getCancelUrl(),
             'success-redirect-url' => $this->redirect->getSuccessUrl()
         ];
-
-        return array_merge(parent::mappedProperties($operation, $parentTransactionType), $specificProperties);
     }
 
     /**

--- a/src/Transaction/SepaTransaction.php
+++ b/src/Transaction/SepaTransaction.php
@@ -67,14 +67,15 @@ class SepaTransaction extends Transaction
     }
 
     /**
-     * @param null $operation
-     * @param null $parentTransactionType
+     * @param string $operation
+     * @param string $parentTransactionType
      * @return array
      */
-    public function mappedProperties($operation = null, $parentTransactionType = null)
+    protected function mappedSpecificProperties($operation, $parentTransactionType)
     {
-        $result = parent::mappedProperties($operation, $parentTransactionType);
-        $result[self::PARAM_TRANSACTION_TYPE] = $this->retrieveTransactionType($operation, $parentTransactionType);
+        $result = [
+            self::PARAM_TRANSACTION_TYPE => $this->retrieveTransactionType($operation, $parentTransactionType)
+        ];
 
         if (null !== $this->iban) {
             $result['bank-account'] = [

--- a/src/Transaction/ThreeDCreditCardTransaction.php
+++ b/src/Transaction/ThreeDCreditCardTransaction.php
@@ -91,14 +91,14 @@ class ThreeDCreditCardTransaction extends CreditCardTransaction
     }
 
     /**
-     * @param string|null $operation
-     * @param string|null $parentTransactionType
+     * @param string $operation
+     * @param string $parentTransactionType
      * @throws MandatoryFieldMissingException|UnsupportedOperationException
      * @return array
      */
-    public function mappedProperties($operation = null, $parentTransactionType = null)
+    protected function mappedSpecificProperties($operation, $parentTransactionType)
     {
-        $result = parent::mappedProperties($operation, $parentTransactionType);
+        $result = parent::mappedSpecificProperties($operation, $parentTransactionType);
 
         if (null !== $this->paRes) {
             $result['three-d'] = [

--- a/src/Transaction/Transaction.php
+++ b/src/Transaction/Transaction.php
@@ -126,7 +126,7 @@ abstract class Transaction
     }
 
     /**
-     * @param string|null $operation
+     * @param string $operation
      * @param string|null $parentTransactionType
      * @return array
      *
@@ -134,7 +134,7 @@ abstract class Transaction
      *  - the common properties are mapped here,
      *  - an abstract operation is defined for the payment type specific properties.
      */
-    public function mappedProperties($operation = null, $parentTransactionType = null)
+    public function mappedProperties($operation, $parentTransactionType = null)
     {
         $result = ['payment-methods' => ['payment-method' => [['name' => $this->retrievePaymentMethodName()]]]];
 

--- a/src/Transaction/Transaction.php
+++ b/src/Transaction/Transaction.php
@@ -39,7 +39,7 @@ use Wirecard\PaymentSdk\Entity\Money;
  * Interface Transaction
  * @package Wirecard\PaymentSdk\Transaction
  */
-abstract class Transaction implements Mappable
+abstract class Transaction
 {
     const PARAM_PAYMENT = 'payment';
     const PARAM_TRANSACTION_TYPE = 'transaction-type';
@@ -129,6 +129,11 @@ abstract class Transaction implements Mappable
      * @param string|null $operation
      * @param string|null $parentTransactionType
      * @return array
+     *
+     * Contains the mapping of the transaction properties.
+     * Subclasses should use the logic below
+     * and add the mapping of their specific properties.
+     * The mapping of the subclass-specific properties often depends on the operation and the parentTransactionType.
      */
     public function mappedProperties($operation = null, $parentTransactionType = null)
     {

--- a/src/Transaction/Transaction.php
+++ b/src/Transaction/Transaction.php
@@ -130,10 +130,9 @@ abstract class Transaction
      * @param string|null $parentTransactionType
      * @return array
      *
-     * Contains the mapping of the transaction properties.
-     * Subclasses should use the logic below
-     * and add the mapping of their specific properties.
-     * The mapping of the subclass-specific properties often depends on the operation and the parentTransactionType.
+     * A template method for the mapping of the transaction properties:
+     *  - the common properties are mapped here,
+     *  - an abstract operation is defined for the payment type specific properties.
      */
     public function mappedProperties($operation = null, $parentTransactionType = null)
     {
@@ -166,8 +165,15 @@ abstract class Transaction
             $result['consumer-id'] = $this->consumerId;
         }
 
-        return $result;
+        return array_merge($result, $this->mappedSpecificProperties($operation, $parentTransactionType));
     }
+
+    /**
+     * @param string $operation
+     * @param string $parentTransactionType
+     * @return array
+     */
+    abstract protected function mappedSpecificProperties($operation, $parentTransactionType);
 
     /**
      * @param string|null

--- a/test/Transaction/TransactionUTest.php
+++ b/test/Transaction/TransactionUTest.php
@@ -46,6 +46,7 @@ class TransactionUTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->tx = $this->getMockForAbstractClass(Transaction::class);
+        $this->tx->method('mappedSpecificProperties')->willReturn([]);
     }
 
     public function testMappingForConsumerId()


### PR DESCRIPTION
Distinguish between a mappable entity and a transaction:

- the mapping of an entity depends only on its properties
- the mapping of a transaction depends on its properties, the operation type (required) and the parent transaction type (optional)

Transaction->mappedProperties

- made the parameter operation required (remove the default value of null)
- refactored the method to the template method pattern