### PR TITLE
SEPA: pay

### DIFF
--- a/examples/Sepa/pay-data-entry.html
+++ b/examples/Sepa/pay-data-entry.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Reserve payment: SEPA</title>
+    <title>Pay: SEPA</title>
 </head>
 <body>
 <form action="pay.php" method="post">

--- a/examples/Sepa/pay-data-entry.html
+++ b/examples/Sepa/pay-data-entry.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Reserve payment: SEPA</title>
+</head>
+<body>
+<form action="reserve.php" method="post">
+    <p>
+        <label for="iban">IBAN:</label><br>
+        <input id="iban" name="iban" value="DE42512308000000060004" style="width:300px"/>
+    </p>
+
+    <p>
+        <label for="bic">BIC:</label><br>
+        <input id="bic" name="bic" value="" style="width:300px"/><br>
+        e.g. WIREDEMMXXX
+    </p>
+
+    <input type="submit"/>
+</form>
+
+</body>
+</html>

--- a/examples/Sepa/pay-data-entry.html
+++ b/examples/Sepa/pay-data-entry.html
@@ -5,7 +5,7 @@
     <title>Reserve payment: SEPA</title>
 </head>
 <body>
-<form action="reserve.php" method="post">
+<form action="pay.php" method="post">
     <p>
         <label for="iban">IBAN:</label><br>
         <input id="iban" name="iban" value="DE42512308000000060004" style="width:300px"/>

--- a/examples/Sepa/pay.php
+++ b/examples/Sepa/pay.php
@@ -24,10 +24,14 @@ $amount = new Money(12.59, 'EUR');
 // Since payment method may have a different merchant ID, a config collection is created.
 $configCollection = new Config\PaymentMethodConfigCollection();
 
-// Create and add a configuration object with the settings for credit card
+// Create and add a configuration object with the settings for SEPA
 $sepaMId = '4c901196-eff7-411e-82a3-5ef6b6860d64';
 $sepaKey = 'ecdf5990-0372-47cd-a55d-037dccfe9d25';
 $sepaDdConfig = new Config\PaymentMethodConfig(SepaTransaction::DIRECT_DEBIT, $sepaMId, $sepaKey);
+
+// In order to execute a pay transaction you also have to provide your creditor ID.
+// Please add it to the config as a specific property with the key 'creditor-id'.
+$sepaDdConfig->addSpecificProperty('creditor-id','DE98ZZZ09999999999');
 $configCollection->add($sepaDdConfig);
 
 // The basic configuration requires the base URL for Wirecard and the username and password for the HTTP requests.

--- a/examples/Sepa/pay.php
+++ b/examples/Sepa/pay.php
@@ -1,0 +1,85 @@
+<?php
+
+// # SEPA amount payment
+// The method `pay` of the _transactionService_ provides the means
+// to execute a payment with an amount (also known as debit).
+
+// To include the necessary files, use the composer for PSR-4 autoloading.
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Wirecard\PaymentSdk\Config;
+use Wirecard\PaymentSdk\Entity\AccountHolder;
+use Wirecard\PaymentSdk\Entity\Mandate;
+use Wirecard\PaymentSdk\Response\FailureResponse;
+use Wirecard\PaymentSdk\Entity\Money;
+use Wirecard\PaymentSdk\Response\SuccessResponse;
+use Wirecard\PaymentSdk\Transaction\SepaTransaction;
+use Wirecard\PaymentSdk\TransactionService;
+
+// Create a money object as amount which has to be payed by the consumer.
+$amount = new Money(12.59, 'EUR');
+
+// ### Config
+
+// Since payment method may have a different merchant ID, a config collection is created.
+$configCollection = new Config\PaymentMethodConfigCollection();
+
+// Create and add a configuration object with the settings for credit card
+$sepaMId = '4c901196-eff7-411e-82a3-5ef6b6860d64';
+$sepaKey = 'ecdf5990-0372-47cd-a55d-037dccfe9d25';
+$sepaDdConfig = new Config\PaymentMethodConfig(SepaTransaction::DIRECT_DEBIT, $sepaMId, $sepaKey);
+$configCollection->add($sepaDdConfig);
+
+// The basic configuration requires the base URL for Wirecard and the username and password for the HTTP requests.
+$baseUrl = 'https://api-test.wirecard.com';
+$httpUser = '70000-APITEST-AP';
+$httpPass = 'qD2wzQ_hrc!8';
+
+// A default currency can also be provided.
+$config = new Config\Config($baseUrl, $httpUser, $httpPass, $configCollection, 'EUR');
+
+
+// ## Transaction
+
+// Create a `CreditCardTransaction` object, which contains all relevant data for the payment process.
+// The token is required as reference to the credit card data.
+$transaction = new SepaTransaction();
+$transaction->setAmount($amount);
+$transaction->setIban($_POST['iban']);
+
+if (null !== $_POST['bic']) {
+    $transaction->setBic($_POST['bic']);
+}
+
+$accountHolder = new AccountHolder('Doe');
+$accountHolder->setFirstName('Jane');
+$transaction->setAccountHolder($accountHolder);
+$mandate = new Mandate('12345678');
+$mandate->setSignedDate(strtotime('2015-08-27'));
+$transaction->setMandate($mandate);
+
+// The service is used to execute the reservation (authorization) operation itself. A response object is returned.
+$transactionService = new TransactionService($config);
+$response = $transactionService->pay($transaction);
+
+// ## Response handling
+
+// The response from the service can be used for disambiguation.
+// In case of a successful transaction, a `SuccessResponse` object is returned.
+if ($response instanceof SuccessResponse) {
+    echo sprintf('Payment with id %s successfully completed.<br>', $response->getTransactionId());
+
+// In case of a failed transaction, a `FailureResponse` object is returned.
+} elseif ($response instanceof FailureResponse) {
+    // In our example we iterate over all errors and display them in a raw state.
+    // You should handle them based on the given severity as error, warning or information.
+    foreach ($response->getStatusCollection() as $status) {
+        /**
+         * @var $status \Wirecard\PaymentSdk\Entity\Status
+         */
+        $severity = ucfirst($status->getSeverity());
+        $code = $status->getCode();
+        $description = $status->getDescription();
+        echo sprintf('%s with code %s and message "%s" occured.<br>', $severity, $code, $description);
+    }
+}

--- a/examples/Sepa/pay.php
+++ b/examples/Sepa/pay.php
@@ -61,7 +61,6 @@ $transaction->setAccountHolder($accountHolder);
 
 // A mandate with ID and signed date is required.
 $mandate = new Mandate('12345678');
-$mandate->setSignedDate(strtotime('2015-08-27'));
 $transaction->setMandate($mandate);
 
 // The service is used to execute the pay (pending-debit) operation itself. A response object is returned.

--- a/examples/Sepa/pay.php
+++ b/examples/Sepa/pay.php
@@ -45,8 +45,7 @@ $config = new Config\Config($baseUrl, $httpUser, $httpPass, $configCollection, '
 
 // ## Transaction
 
-// Create a `CreditCardTransaction` object, which contains all relevant data for the payment process.
-// The token is required as reference to the credit card data.
+// Create a `SepaTransaction` object, which contains all relevant data for the payment process.
 $transaction = new SepaTransaction();
 $transaction->setAmount($amount);
 $transaction->setIban($_POST['iban']);
@@ -55,14 +54,17 @@ if (null !== $_POST['bic']) {
     $transaction->setBic($_POST['bic']);
 }
 
+// The account holder (first name, last name) is required.
 $accountHolder = new AccountHolder('Doe');
 $accountHolder->setFirstName('Jane');
 $transaction->setAccountHolder($accountHolder);
+
+// A mandate with ID and signed date is required.
 $mandate = new Mandate('12345678');
 $mandate->setSignedDate(strtotime('2015-08-27'));
 $transaction->setMandate($mandate);
 
-// The service is used to execute the reservation (authorization) operation itself. A response object is returned.
+// The service is used to execute the pay (pending-debit) operation itself. A response object is returned.
 $transactionService = new TransactionService($config);
 $response = $transactionService->pay($transaction);
 

--- a/examples/Sepa/reserve.php
+++ b/examples/Sepa/reserve.php
@@ -25,7 +25,7 @@ $amount = new Money(12.59, 'EUR');
 // Since payment method may have a different merchant ID, a config collection is created.
 $configCollection = new Config\PaymentMethodConfigCollection();
 
-// Create and add a configuration object with the settings for credit card
+// Create and add a configuration object with the settings for SEPA
 $sepaMId = '4c901196-eff7-411e-82a3-5ef6b6860d64';
 $sepaKey = 'ecdf5990-0372-47cd-a55d-037dccfe9d25';
 $sepaDdConfig = new Config\PaymentMethodConfig(SepaTransaction::DIRECT_DEBIT, $sepaMId, $sepaKey);
@@ -42,8 +42,7 @@ $config = new Config\Config($baseUrl, $httpUser, $httpPass, $configCollection, '
 
 // ## Transaction
 
-// Create a `CreditCardTransaction` object, which contains all relevant data for the payment process.
-// The token is required as reference to the credit card data.
+// Create a `SepaTransaction` object, which contains all relevant data for the payment process.
 $transaction = new SepaTransaction();
 $transaction->setAmount($amount);
 $transaction->setIban($_POST['iban']);

--- a/src/Config/PaymentMethodConfig.php
+++ b/src/Config/PaymentMethodConfig.php
@@ -53,7 +53,7 @@ class PaymentMethodConfig implements MappableEntity
     /**
      * @var array
      */
-    private $specificProperties;
+    private $specificProperties = [];
 
     /**
      * PaymentMethodConfig constructor.
@@ -66,7 +66,6 @@ class PaymentMethodConfig implements MappableEntity
         $this->paymentMethodName = $paymentMethodName;
         $this->merchantAccountId = $merchantAccountId;
         $this->secret = $secret;
-        $this->specificProperties = [];
     }
 
     /**

--- a/src/Config/PaymentMethodConfig.php
+++ b/src/Config/PaymentMethodConfig.php
@@ -31,7 +31,9 @@
 
 namespace Wirecard\PaymentSdk\Config;
 
-class PaymentMethodConfig
+use Wirecard\PaymentSdk\Entity\MappableEntity;
+
+class PaymentMethodConfig implements MappableEntity
 {
     /**
      * @var string
@@ -49,6 +51,11 @@ class PaymentMethodConfig
     private $secret;
 
     /**
+     * @var array
+     */
+    private $specificProperties;
+
+    /**
      * PaymentMethodConfig constructor.
      * @param string $paymentMethodName
      * @param string $merchantAccountId
@@ -59,6 +66,7 @@ class PaymentMethodConfig
         $this->paymentMethodName = $paymentMethodName;
         $this->merchantAccountId = $merchantAccountId;
         $this->secret = $secret;
+        $this->specificProperties = [];
     }
 
     /**
@@ -83,5 +91,22 @@ class PaymentMethodConfig
     public function getSecret()
     {
         return $this->secret;
+    }
+
+    /**
+     * @param string $key
+     * @param string $value
+     */
+    public function addSpecificProperty($key, $value)
+    {
+        $this->specificProperties[$key] = $value;
+    }
+
+    /**
+     * @return array
+     */
+    public function mappedProperties()
+    {
+        return $this->specificProperties;
     }
 }

--- a/src/Entity/Mandate.php
+++ b/src/Entity/Mandate.php
@@ -40,11 +40,6 @@ class Mandate implements MappableEntity
     private $id;
 
     /**
-     * @var \DateTime
-     */
-    private $signedDate;
-
-    /**
      * Mandate constructor.
      * @param string $id
      */
@@ -53,24 +48,11 @@ class Mandate implements MappableEntity
         $this->id = $id;
     }
 
-    /**
-     * @param \DateTime $signedDate
-     */
-    public function setSignedDate($signedDate)
-    {
-        $this->signedDate = $signedDate;
-    }
-
     public function mappedProperties()
     {
-        $result = [
-            'mandate-id' => $this->id
+        return [
+            'mandate-id' => $this->id,
+            'signed-date' => gmdate('Y-m-d')
         ];
-
-        if (null !== $this->signedDate) {
-            $result['signed-date'] = date('Y-m-d', $this->signedDate);
-        }
-
-        return $result;
     }
 }

--- a/src/Entity/Mandate.php
+++ b/src/Entity/Mandate.php
@@ -67,7 +67,7 @@ class Mandate implements MappableEntity
             'mandate-id' => $this->id
         ];
 
-        if (null !== $this->signedDate){
+        if (null !== $this->signedDate) {
             $result['signed-date'] = date('Y-m-d', $this->signedDate);
         }
 

--- a/src/Entity/Mandate.php
+++ b/src/Entity/Mandate.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Shop System Plugins - Terms of Use
+ *
+ * The plugins offered are provided free of charge by Wirecard Central Eastern Europe GmbH
+ * (abbreviated to Wirecard CEE) and are explicitly not part of the Wirecard CEE range of
+ * products and services.
+ *
+ * They have been tested and approved for full functionality in the standard configuration
+ * (status on delivery) of the corresponding shop system. They are under General Public
+ * License Version 3 (GPLv3) and can be used, developed and passed on to third parties under
+ * the same terms.
+ *
+ * However, Wirecard CEE does not provide any guarantee or accept any liability for any errors
+ * occurring when used in an enhanced, customized shop system configuration.
+ *
+ * Operation in an enhanced, customized configuration is at your own risk and requires a
+ * comprehensive test phase by the user of the plugin.
+ *
+ * Customers use the plugins at their own risk. Wirecard CEE does not guarantee their full
+ * functionality neither does Wirecard CEE assume liability for any disadvantages related to
+ * the use of the plugins. Additionally, Wirecard CEE does not guarantee the full functionality
+ * for customized shop systems or installed plugins of other vendors of plugins within the same
+ * shop system.
+ *
+ * Customers are responsible for testing the plugin's functionality before starting productive
+ * operation.
+ *
+ * By installing the plugin into the shop system the customer agrees to these terms of use.
+ * Please do not use the plugin if you do not agree to these terms of use!
+ */
+
+namespace Wirecard\PaymentSdk\Entity;
+
+class Mandate implements MappableEntity
+{
+    /**
+     * @var string
+     */
+    private $id;
+
+    /**
+     * @var \DateTime
+     */
+    private $signedDate;
+
+    /**
+     * Mandate constructor.
+     * @param string $id
+     */
+    public function __construct($id)
+    {
+        $this->id = $id;
+    }
+
+    /**
+     * @param \DateTime $signedDate
+     */
+    public function setSignedDate($signedDate)
+    {
+        $this->signedDate = $signedDate;
+    }
+
+    public function mappedProperties()
+    {
+        $result = [
+            'mandate-id' => $this->id
+        ];
+
+        if (null !== $this->signedDate){
+            $result['signed-date'] = date('Y-m-d', $this->signedDate);
+        }
+
+        return $result;
+    }
+}

--- a/src/Mapper/RequestMapper.php
+++ b/src/Mapper/RequestMapper.php
@@ -77,9 +77,15 @@ class RequestMapper
             'request-id' => $requestId
         ];
 
+        $paymentMethodConfig = $this->config->get(
+            $transaction->getConfigKey($operation, $parentTransactionType)
+        );
+        $paymentMethodConfigProperties = $paymentMethodConfig->mappedProperties();
+
         $allProperties = array_merge(
             $commonProperties,
-            $transaction->mappedProperties($operation, $parentTransactionType)
+            $transaction->mappedProperties($operation, $parentTransactionType),
+            $paymentMethodConfigProperties
         );
 
         $allProperties['merchant-account-id']['value'] = $this->config->get($transaction->getConfigKey())

--- a/src/Transaction/SepaTransaction.php
+++ b/src/Transaction/SepaTransaction.php
@@ -32,6 +32,7 @@
 
 namespace Wirecard\PaymentSdk\Transaction;
 
+use Wirecard\PaymentSdk\Entity\Mandate;
 use Wirecard\PaymentSdk\Exception\UnsupportedOperationException;
 
 class SepaTransaction extends Transaction
@@ -51,6 +52,11 @@ class SepaTransaction extends Transaction
     private $bic;
 
     /**
+     * @var Mandate
+     */
+    private $mandate;
+
+    /**
      * @param string $iban
      */
     public function setIban($iban)
@@ -64,6 +70,14 @@ class SepaTransaction extends Transaction
     public function setBic($bic)
     {
         $this->bic = $bic;
+    }
+
+    /**
+     * @param Mandate $mandate
+     */
+    public function setMandate($mandate)
+    {
+        $this->mandate = $mandate;
     }
 
     /**

--- a/src/Transaction/SepaTransaction.php
+++ b/src/Transaction/SepaTransaction.php
@@ -100,6 +100,10 @@ class SepaTransaction extends Transaction
             }
         }
 
+        if (null !== $this->mandate) {
+            $result['mandate'] = $this->mandate->mappedProperties();
+        }
+
         return $result;
     }
 

--- a/test/Config/PaymentMethodConfigUTest.php
+++ b/test/Config/PaymentMethodConfigUTest.php
@@ -65,4 +65,33 @@ class PaymentMethodConfigUTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEquals(self::SECRET, $this->instance->getSecret());
     }
+
+    public function testMappedPropertiesWithoutSpecificProperties()
+    {
+        $this->assertEquals([], $this->instance->mappedProperties());
+    }
+
+    public function testMappedPropertiesWith1SpecificProperty()
+    {
+        $this->instance->addSpecificProperty('creditor-id', 'anything');
+
+        $this->assertEquals(
+            [ 'creditor-id' => 'anything' ],
+            $this->instance->mappedProperties()
+        );
+    }
+
+    public function testMappedPropertiesWith2SpecificProperties()
+    {
+        $this->instance->addSpecificProperty('creditor-id', 'anything');
+        $this->instance->addSpecificProperty('dummy-id', 'bla');
+
+        $this->assertEquals(
+            [
+                'creditor-id' => 'anything',
+                'dummy-id' => 'bla'
+            ],
+            $this->instance->mappedProperties()
+        );
+    }
 }

--- a/test/Entity/MandateUTest.php
+++ b/test/Entity/MandateUTest.php
@@ -48,26 +48,12 @@ class MandateUTest extends \PHPUnit_Framework_TestCase
         $this->mandate = new Mandate(self::ID);
     }
 
-    public function testMappedPropertiesWithoutSignedDate()
+    public function testMappedProperties()
     {
-        $expectedResult = [
-            'mandate-id' => self::ID
-        ];
-
-        $result = $this->mandate->mappedProperties();
-
-        $this->assertEquals($expectedResult, $result);
-    }
-
-    public function testMappedPropertiesWithSignedDate()
-    {
-        $dateAsStr = '2017-03-24';
-        $signedDate = strtotime($dateAsStr);
-        $this->mandate->setSignedDate($signedDate);
-
+        $today = gmdate('Y-m-d');
         $expectedResult = [
             'mandate-id' => self::ID,
-            'signed-date' => $dateAsStr
+            'signed-date' => $today
         ];
 
         $result = $this->mandate->mappedProperties();

--- a/test/Entity/MandateUTest.php
+++ b/test/Entity/MandateUTest.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Shop System Plugins - Terms of Use
+ *
+ * The plugins offered are provided free of charge by Wirecard Central Eastern Europe GmbH
+ * (abbreviated to Wirecard CEE) and are explicitly not part of the Wirecard CEE range of
+ * products and services.
+ *
+ * They have been tested and approved for full functionality in the standard configuration
+ * (status on delivery) of the corresponding shop system. They are under General Public
+ * License Version 3 (GPLv3) and can be used, developed and passed on to third parties under
+ * the same terms.
+ *
+ * However, Wirecard CEE does not provide any guarantee or accept any liability for any errors
+ * occurring when used in an enhanced, customized shop system configuration.
+ *
+ * Operation in an enhanced, customized configuration is at your own risk and requires a
+ * comprehensive test phase by the user of the plugin.
+ *
+ * Customers use the plugins at their own risk. Wirecard CEE does not guarantee their full
+ * functionality neither does Wirecard CEE assume liability for any disadvantages related to
+ * the use of the plugins. Additionally, Wirecard CEE does not guarantee the full functionality
+ * for customized shop systems or installed plugins of other vendors of plugins within the same
+ * shop system.
+ *
+ * Customers are responsible for testing the plugin's functionality before starting productive
+ * operation.
+ *
+ * By installing the plugin into the shop system the customer agrees to these terms of use.
+ * Please do not use the plugin if you do not agree to these terms of use!
+ */
+
+namespace WirecardTest\PaymentSdk\Entity;
+
+use Wirecard\PaymentSdk\Entity\Mandate;
+
+class MandateUTest extends \PHPUnit_Framework_TestCase
+{
+    const ID = '345';
+
+    /**
+     * @var Mandate
+     */
+    private $mandate;
+
+    public function setUp()
+    {
+        $this->mandate = new Mandate(self::ID);
+    }
+
+    public function testMappedPropertiesWithoutSignedDate()
+    {
+        $expectedResult = [
+            'mandate-id' => self::ID
+        ];
+
+        $result = $this->mandate->mappedProperties();
+
+        $this->assertEquals($expectedResult, $result);
+    }
+
+    public function testMappedPropertiesWithSignedDate()
+    {
+        $dateAsStr = '2017-03-24';
+        $signedDate = strtotime($dateAsStr);
+        $this->mandate->setSignedDate($signedDate);
+
+        $expectedResult = [
+            'mandate-id' => self::ID,
+            'signed-date' => $dateAsStr
+        ];
+
+        $result = $this->mandate->mappedProperties();
+
+        $this->assertEquals($expectedResult, $result);
+    }
+}

--- a/test/Mapper/RequestMapperUTest.php
+++ b/test/Mapper/RequestMapperUTest.php
@@ -55,6 +55,7 @@ class RequestMapperUTest extends \PHPUnit_Framework_TestCase
     {
         $paymentMethodConfig = $this->createMock(PaymentMethodConfig::class);
         $paymentMethodConfig->method('getMerchantAccountId')->willReturn(self::MAID);
+        $paymentMethodConfig->method('mappedProperties')->willReturn([]);
         $paymentMethodConfigs = $this->createMock(PaymentMethodConfigCollection::class);
         $paymentMethodConfigs->method('get')->willReturn($paymentMethodConfig);
 
@@ -89,6 +90,7 @@ class RequestMapperUTest extends \PHPUnit_Framework_TestCase
         $_SERVER['REMOTE_ADDR'] = 'test IP';
         $paymentMethodConfig = $this->createMock(PaymentMethodConfig::class);
         $paymentMethodConfig->method('getMerchantAccountId')->willReturn(self::MAID);
+        $paymentMethodConfig->method('mappedProperties')->willReturn([]);
         $paymentMethodConfigs = $this->createMock(PaymentMethodConfigCollection::class);
         $paymentMethodConfigs->method('get')->willReturn($paymentMethodConfig);
 
@@ -122,6 +124,7 @@ class RequestMapperUTest extends \PHPUnit_Framework_TestCase
         $_SERVER['REMOTE_ADDR'] = 'test IP';
         $paymentMethodConfig = $this->createMock(PaymentMethodConfig::class);
         $paymentMethodConfig->method('getMerchantAccountId')->willReturn(self::MAID);
+        $paymentMethodConfig->method('mappedProperties')->willReturn([]);
         $paymentMethodConfigs = $this->createMock(PaymentMethodConfigCollection::class);
         $paymentMethodConfigs->method('get')->willReturn($paymentMethodConfig);
 
@@ -172,6 +175,7 @@ class RequestMapperUTest extends \PHPUnit_Framework_TestCase
         $_SERVER['REMOTE_ADDR'] = 'test IP';
         $paymentMethodConfig = $this->createMock(PaymentMethodConfig::class);
         $paymentMethodConfig->method('getMerchantAccountId')->willReturn(self::MAID);
+        $paymentMethodConfig->method('mappedProperties')->willReturn([]);
         $paymentMethodConfigs = $this->createMock(PaymentMethodConfigCollection::class);
         $paymentMethodConfigs->method('get')->willReturn($paymentMethodConfig);
 
@@ -235,6 +239,7 @@ class RequestMapperUTest extends \PHPUnit_Framework_TestCase
         $_SERVER['REMOTE_ADDR'] = 'test IP';
         $paymentMethodConfig = $this->createMock(PaymentMethodConfig::class);
         $paymentMethodConfig->method('getMerchantAccountId')->willReturn(self::MAID);
+        $paymentMethodConfig->method('mappedProperties')->willReturn([]);
         $paymentMethodConfigs = $this->createMock(PaymentMethodConfigCollection::class);
         $paymentMethodConfigs->method('get')->willReturn($paymentMethodConfig);
 
@@ -275,6 +280,7 @@ class RequestMapperUTest extends \PHPUnit_Framework_TestCase
         $_SERVER['REMOTE_ADDR'] = 'test IP';
         $paymentMethodConfig = $this->createMock(PaymentMethodConfig::class);
         $paymentMethodConfig->method('getMerchantAccountId')->willReturn(self::MAID);
+        $paymentMethodConfig->method('mappedProperties')->willReturn([]);
         $paymentMethodConfigs = $this->createMock(PaymentMethodConfigCollection::class);
         $paymentMethodConfigs->method('get')->willReturn($paymentMethodConfig);
 
@@ -324,6 +330,7 @@ class RequestMapperUTest extends \PHPUnit_Framework_TestCase
     {
         $paymentMethodConfig = $this->createMock(PaymentMethodConfig::class);
         $paymentMethodConfig->method('getMerchantAccountId')->willReturn(self::MAID);
+        $paymentMethodConfig->method('mappedProperties')->willReturn([]);
         $paymentMethodConfigs = $this->createMock(PaymentMethodConfigCollection::class);
         $paymentMethodConfigs->method('get')->willReturn($paymentMethodConfig);
 
@@ -374,6 +381,7 @@ class RequestMapperUTest extends \PHPUnit_Framework_TestCase
     {
         $paymentMethodConfig = $this->createMock(PaymentMethodConfig::class);
         $paymentMethodConfig->method('getMerchantAccountId')->willReturn(self::MAID);
+        $paymentMethodConfig->method('mappedProperties')->willReturn([]);
         $paymentMethodConfigs = $this->createMock(PaymentMethodConfigCollection::class);
         $paymentMethodConfigs->method('get')->willReturn($paymentMethodConfig);
 
@@ -428,6 +436,7 @@ class RequestMapperUTest extends \PHPUnit_Framework_TestCase
     {
         $paymentMethodConfig = $this->createMock(PaymentMethodConfig::class);
         $paymentMethodConfig->method('getMerchantAccountId')->willReturn(self::MAID);
+        $paymentMethodConfig->method('mappedProperties')->willReturn([]);
         $paymentMethodConfigs = $this->createMock(PaymentMethodConfigCollection::class);
         $paymentMethodConfigs->method('get')->willReturn($paymentMethodConfig);
 
@@ -458,6 +467,7 @@ class RequestMapperUTest extends \PHPUnit_Framework_TestCase
     {
         $paymentMethodConfig = $this->createMock(PaymentMethodConfig::class);
         $paymentMethodConfig->method('getMerchantAccountId')->willReturn(self::MAID);
+        $paymentMethodConfig->method('mappedProperties')->willReturn([]);
         $paymentMethodConfigs = $this->createMock(PaymentMethodConfigCollection::class);
         $paymentMethodConfigs->method('get')->willReturn($paymentMethodConfig);
 
@@ -475,6 +485,7 @@ class RequestMapperUTest extends \PHPUnit_Framework_TestCase
     {
         $paymentMethodConfig = $this->createMock(PaymentMethodConfig::class);
         $paymentMethodConfig->method('getMerchantAccountId')->willReturn(self::MAID);
+        $paymentMethodConfig->method('mappedProperties')->willReturn([]);
         $paymentMethodConfigs = $this->createMock(PaymentMethodConfigCollection::class);
         $paymentMethodConfigs->method('get')->willReturn($paymentMethodConfig);
 

--- a/test/Transaction/SepaTransactionUTest.php
+++ b/test/Transaction/SepaTransactionUTest.php
@@ -44,7 +44,6 @@ class SepaTransactionUTest extends \PHPUnit_Framework_TestCase
     const LAST_NAME = 'Doe';
     const FIRST_NAME = 'Jane';
     const MANDATE_ID = '2345';
-    const MANDATE_SIGNED_DATE = '2017-05-05';
 
     /**
      * @var SepaTransaction
@@ -132,7 +131,6 @@ class SepaTransactionUTest extends \PHPUnit_Framework_TestCase
         $this->tx->setAccountHolder($this->accountHolder);
 
         $mandate = new Mandate(self::MANDATE_ID);
-        $mandate->setSignedDate(strtotime(self::MANDATE_SIGNED_DATE));
         $this->tx->setMandate($mandate);
 
         $expectedResult = $this->getExpectedResultPayIbanOnly();
@@ -169,7 +167,7 @@ class SepaTransactionUTest extends \PHPUnit_Framework_TestCase
             ],
             'mandate' => [
                 'mandate-id' => self::MANDATE_ID,
-                'signed-date' => self::MANDATE_SIGNED_DATE
+                'signed-date' => $this->today()
             ]
         ];
     }
@@ -231,5 +229,13 @@ class SepaTransactionUTest extends \PHPUnit_Framework_TestCase
             ],
             'parent-transaction-id' => $parentTransactionId
         ];
+    }
+
+    /**
+     * @return false|string
+     */
+    private function today()
+    {
+        return gmdate('Y-m-d');
     }
 }

--- a/test/TransactionServiceUTest.php
+++ b/test/TransactionServiceUTest.php
@@ -67,6 +67,7 @@ class TransactionServiceUTest extends \PHPUnit_Framework_TestCase
     {
         $paymentMethodConfig = $this->createMock(PaymentMethodConfig::class);
         $paymentMethodConfig->method('getMerchantAccountId')->willReturn(self::MAID);
+        $paymentMethodConfig->method('mappedProperties')->willReturn([]);
 
         $this->config = $this->createMock('\Wirecard\PaymentSdk\Config\Config');
         $this->config->method('getHttpUser')->willReturn('abc123');


### PR DESCRIPTION
Implemented the operation pay (pending-debit) for SEPA.

- introduced entity Mandate
- PaymentMethodConfig: added specific properties so that we can configure creditor ID for SEPA

Example includes:

- IBAN only
- IBAN & BIC

Questions:
PaymentMethodConfig contains a method addSpecificProperty(string, string) at the moment.
Another possibility would be: addSpecificProperties(array)