### PR TITLE
correct SEPA-links: example => docs #59

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -49,13 +49,16 @@
         <div class="col-sm-4">
             <h2>SEPA</h2>
             <div class="list-group">
-                <a href="Sepa/reserve-data-entry.html" class="list-group-item">Reserve an amount</a>
+                <a href="Sepa/reserve.html" class="list-group-item">Reserve an amount</a>
             </div>
             <div class="list-group">
-                <a href="Sepa/pay-data-entry.html" class="list-group-item">Execute a payment</a>
+                <a href="Sepa/pay.html" class="list-group-item">Execute a payment</a>
             </div>
             <div class="list-group">
-                <a href="Sepa/credit-data-entry.html" class="list-group-item">Credit</a>
+                <a href="Sepa/credit.html" class="list-group-item">Credit</a>
+            </div>
+            <div class="list-group">
+                <a href="Sepa/cancel.html" class="list-group-item">Cancelling a transaction</a>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Correct links so that they show to the docs, not to the example data entry forms.