### PR TITLE
Config key refactoring

### DIFF
--- a/examples/CreditCard/3d-pay.php
+++ b/examples/CreditCard/3d-pay.php
@@ -62,7 +62,7 @@ $configCollection = new Config\PaymentMethodConfigCollection();
 // For 3-D Secure transactions the corresponding merchant account ID is required.
 $ccard3dMId = '33f6d473-3036-4ca5-acb5-8c64dac862d1';
 $ccard3dKey = '9e0130f6-2e1e-4185-b0d5-dc69079c75cc';
-$ccard3dConfig = new Config\PaymentMethodConfig(ThreeDCreditCardTransaction::class, $ccard3dMId, $ccard3dKey);
+$ccard3dConfig = new Config\PaymentMethodConfig(ThreeDCreditCardTransaction::NAME, $ccard3dMId, $ccard3dKey);
 $configCollection->add($ccard3dConfig);
 
 // The basic configuration requires the base URL for Wirecard and the username and password for the HTTP requests.

--- a/examples/CreditCard/3d-reserve.php
+++ b/examples/CreditCard/3d-reserve.php
@@ -54,7 +54,7 @@ $configCollection = new Config\PaymentMethodConfigCollection();
 // than for the previously executed _seamlessRenderForm_.
 $ccard3dMId = '33f6d473-3036-4ca5-acb5-8c64dac862d1';
 $ccard3dKey = '9e0130f6-2e1e-4185-b0d5-dc69079c75cc';
-$ccard3dConfig = new Config\PaymentMethodConfig(ThreeDCreditCardTransaction::class, $ccard3dMId, $ccard3dKey);
+$ccard3dConfig = new Config\PaymentMethodConfig(ThreeDCreditCardTransaction::NAME, $ccard3dMId, $ccard3dKey);
 $configCollection->add($ccard3dConfig);
 
 // The basic configuration requires the base URL for Wirecard and the username and password for the HTTP requests.

--- a/examples/CreditCard/cancel.php
+++ b/examples/CreditCard/cancel.php
@@ -23,13 +23,13 @@ $configCollection = new Config\PaymentMethodConfigCollection();
 // Create and add a configuration object with the settings for credit card.
 $ccardMId = '9105bb4f-ae68-4768-9c3b-3eda968f57ea';
 $ccardKey = 'd1efed51-4cb9-46a5-ba7b-0fdc87a66544';
-$ccardConfig = new Config\PaymentMethodConfig(CreditCardTransaction::class, $ccardMId, $ccardKey);
+$ccardConfig = new Config\PaymentMethodConfig(CreditCardTransaction::NAME, $ccardMId, $ccardKey);
 $configCollection->add($ccardConfig);
 
 // For 3-D Secure transactions a different merchant account ID is required.
 $ccard3dMId = '33f6d473-3036-4ca5-acb5-8c64dac862d1';
 $ccard3dKey = '9e0130f6-2e1e-4185-b0d5-dc69079c75cc';
-$ccard3dConfig = new Config\PaymentMethodConfig(ThreeDCreditCardTransaction::class, $ccard3dMId, $ccard3dKey);
+$ccard3dConfig = new Config\PaymentMethodConfig(ThreeDCreditCardTransaction::NAME, $ccard3dMId, $ccard3dKey);
 $configCollection->add($ccard3dConfig);
 
 // The basic configuration requires the base URL for Wirecard and the username and password for the HTTP requests.

--- a/examples/CreditCard/createUi.php
+++ b/examples/CreditCard/createUi.php
@@ -24,7 +24,7 @@ $configCollection = new Config\PaymentMethodConfigCollection();
 // Create and add a configuration object with the settings for credit card.
 $ccardMId = '9105bb4f-ae68-4768-9c3b-3eda968f57ea';
 $ccardKey = 'd1efed51-4cb9-46a5-ba7b-0fdc87a66544';
-$ccardConfig = new Config\PaymentMethodConfig(CreditCardTransaction::class, $ccardMId, $ccardKey);
+$ccardConfig = new Config\PaymentMethodConfig(CreditCardTransaction::NAME, $ccardMId, $ccardKey);
 $configCollection->add($ccardConfig);
 
 // The basic configuration requires the base URL for Wirecard and the username and password for the HTTP requests.

--- a/examples/CreditCard/credit.php
+++ b/examples/CreditCard/credit.php
@@ -29,7 +29,7 @@ $configCollection = new Config\PaymentMethodConfigCollection();
 // Create and add a configuration object with the settings for credit card.
 $ccardMId = '33f6d473-3036-4ca5-acb5-8c64dac862d1';
 $ccardKey = '9e0130f6-2e1e-4185-b0d5-dc69079c75cc';
-$ccardConfig = new Config\PaymentMethodConfig(CreditCardTransaction::class, $ccardMId, $ccardKey);
+$ccardConfig = new Config\PaymentMethodConfig(CreditCardTransaction::NAME, $ccardMId, $ccardKey);
 $configCollection->add($ccardConfig);
 
 // The basic configuration requires the base URL for Wirecard and the username and password for the HTTP requests.

--- a/examples/CreditCard/pay-based-on-reserve.php
+++ b/examples/CreditCard/pay-based-on-reserve.php
@@ -23,13 +23,13 @@ $configCollection = new Config\PaymentMethodConfigCollection();
 // Create and add a configuration object with the settings for credit card.
 $ccardMId = '9105bb4f-ae68-4768-9c3b-3eda968f57ea';
 $ccardKey = 'd1efed51-4cb9-46a5-ba7b-0fdc87a66544';
-$ccardConfig = new Config\PaymentMethodConfig(CreditCardTransaction::class, $ccardMId, $ccardKey);
+$ccardConfig = new Config\PaymentMethodConfig(CreditCardTransaction::NAME, $ccardMId, $ccardKey);
 $configCollection->add($ccardConfig);
 
 // For 3-D Secure transactions a different merchant account ID is required.
 $ccard3dMId = '33f6d473-3036-4ca5-acb5-8c64dac862d1';
 $ccard3dKey = '9e0130f6-2e1e-4185-b0d5-dc69079c75cc';
-$ccard3dConfig = new Config\PaymentMethodConfig(ThreeDCreditCardTransaction::class, $ccard3dMId, $ccard3dKey);
+$ccard3dConfig = new Config\PaymentMethodConfig(ThreeDCreditCardTransaction::NAME, $ccard3dMId, $ccard3dKey);
 $configCollection->add($ccard3dConfig);
 
 // The basic configuration requires the base URL for Wirecard and the username and password for the HTTP requests.

--- a/examples/CreditCard/return.php
+++ b/examples/CreditCard/return.php
@@ -26,13 +26,13 @@ $configCollection = new Config\PaymentMethodConfigCollection();
 
 $ccardMId = '9105bb4f-ae68-4768-9c3b-3eda968f57ea';
 $ccardKey = 'd1efed51-4cb9-46a5-ba7b-0fdc87a66544';
-$ccardConfig = new Config\PaymentMethodConfig(CreditCardTransaction::class, $ccardMId, $ccardKey);
+$ccardConfig = new Config\PaymentMethodConfig(CreditCardTransaction::NAME, $ccardMId, $ccardKey);
 $configCollection->add($ccardConfig);
 
 // For 3-D Secure transactions a different merchant account ID is required.
 $ccard3dMId = '33f6d473-3036-4ca5-acb5-8c64dac862d1';
 $ccard3dKey = '9e0130f6-2e1e-4185-b0d5-dc69079c75cc';
-$ccard3dConfig = new Config\PaymentMethodConfig(ThreeDCreditCardTransaction::class, $ccard3dMId, $ccard3dKey);
+$ccard3dConfig = new Config\PaymentMethodConfig(ThreeDCreditCardTransaction::NAME, $ccard3dMId, $ccard3dKey);
 $configCollection->add($ccard3dConfig);
 
 // The basic configuration requires the base URL for Wirecard and the username and password for the HTTP requests.

--- a/examples/CreditCard/ssl-pay.php
+++ b/examples/CreditCard/ssl-pay.php
@@ -39,7 +39,7 @@ $configCollection = new Config\PaymentMethodConfigCollection();
 // Create and add a configuration object with the settings for credit card.
 $ccardMId = '9105bb4f-ae68-4768-9c3b-3eda968f57ea';
 $ccardKey = 'd1efed51-4cb9-46a5-ba7b-0fdc87a66544';
-$ccardConfig = new Config\PaymentMethodConfig(CreditCardTransaction::class, $ccardMId, $ccardKey);
+$ccardConfig = new Config\PaymentMethodConfig(CreditCardTransaction::NAME, $ccardMId, $ccardKey);
 $configCollection->add($ccardConfig);
 
 // The basic configuration requires the base URL for Wirecard and the username and password for the HTTP requests.

--- a/examples/CreditCard/ssl-reserve.php
+++ b/examples/CreditCard/ssl-reserve.php
@@ -38,7 +38,7 @@ $configCollection = new Config\PaymentMethodConfigCollection();
 // Create and add a configuration object with the settings for credit card
 $ccardMId = '9105bb4f-ae68-4768-9c3b-3eda968f57ea';
 $ccardKey = 'd1efed51-4cb9-46a5-ba7b-0fdc87a66544';
-$ccardConfig = new Config\PaymentMethodConfig(CreditCardTransaction::class, $ccardMId, $ccardKey);
+$ccardConfig = new Config\PaymentMethodConfig(CreditCardTransaction::NAME, $ccardMId, $ccardKey);
 $configCollection->add($ccardConfig);
 
 // The basic configuration requires the base URL for Wirecard and the username and password for the HTTP requests.

--- a/examples/PayPal/notify.php
+++ b/examples/PayPal/notify.php
@@ -21,7 +21,7 @@ $configCollection = new Config\PaymentMethodConfigCollection();
 // Create and add a configuration object with the PayPal settings
 $paypalMId = '9abf05c1-c266-46ae-8eac-7f87ca97af28';
 $paypalKey = '5fca2a83-89ca-4f9e-8cf7-4ca74a02773f';
-$paypalConfig = new Config\PaymentMethodConfig(PayPalTransaction::class, $paypalMId, $paypalKey);
+$paypalConfig = new Config\PaymentMethodConfig(PayPalTransaction::NAME, $paypalMId, $paypalKey);
 $configCollection->add($paypalConfig);
 
 // The basic configuration requires the base URL for Wirecard and the username and password for the HTTP requests.

--- a/examples/PayPal/pay.php
+++ b/examples/PayPal/pay.php
@@ -59,7 +59,7 @@ $configCollection = new Config\PaymentMethodConfigCollection();
 // Create and add a configuration object with the PayPal settings
 $paypalMId = '9abf05c1-c266-46ae-8eac-7f87ca97af28';
 $paypalKey = '5fca2a83-89ca-4f9e-8cf7-4ca74a02773f';
-$paypalConfig = new Config\PaymentMethodConfig(PayPalTransaction::class, $paypalMId, $paypalKey);
+$paypalConfig = new Config\PaymentMethodConfig(PayPalTransaction::NAME, $paypalMId, $paypalKey);
 $configCollection->add($paypalConfig);
 
 // The basic configuration requires the base URL for Wirecard and the username and password for the HTTP requests.

--- a/examples/PayPal/return.php
+++ b/examples/PayPal/return.php
@@ -19,7 +19,7 @@ $configCollection = new Config\PaymentMethodConfigCollection();
 // Create and add a configuration object with the PayPal settings
 $paypalMId = '9abf05c1-c266-46ae-8eac-7f87ca97af28';
 $paypalKey = '5fca2a83-89ca-4f9e-8cf7-4ca74a02773f';
-$paypalConfig = new Config\PaymentMethodConfig(PayPalTransaction::class, $paypalMId, $paypalKey);
+$paypalConfig = new Config\PaymentMethodConfig(PayPalTransaction::NAME, $paypalMId, $paypalKey);
 $configCollection->add($paypalConfig);
 
 // The basic configuration requires the base URL for Wirecard and the username and password for the HTTP requests.

--- a/examples/Sofort/pay.php
+++ b/examples/Sofort/pay.php
@@ -56,7 +56,7 @@ $configCollection = new Config\PaymentMethodConfigCollection();
 // Create and add a configuration object with the Sofortbanking settings
 $sofortMId = 'f19d17a2-01ae-11e2-9085-005056a96a54';
 $sofortSecretKey = 'ad39d9d9-2712-4abd-9016-cdeb60dc3c8f';
-$sofortConfig = new Config\PaymentMethodConfig(SofortTransaction::class, $sofortMId, $sofortSecretKey);
+$sofortConfig = new Config\PaymentMethodConfig(SofortTransaction::NAME, $sofortMId, $sofortSecretKey);
 $configCollection->add($sofortConfig);
 
 // The basic configuration requires the base URL for Wirecard and the username and password for the HTTP requests.

--- a/examples/Sofort/return.php
+++ b/examples/Sofort/return.php
@@ -19,7 +19,7 @@ $configCollection = new Config\PaymentMethodConfigCollection();
 // Create and add a configuration object with the Sofortbanking settings
 $sofortMId = 'f19d17a2-01ae-11e2-9085-005056a96a54';
 $sofortSecretKey = 'ad39d9d9-2712-4abd-9016-cdeb60dc3c8f';
-$sofortConfig = new Config\PaymentMethodConfig(SofortTransaction::class, $sofortMId, $sofortSecretKey);
+$sofortConfig = new Config\PaymentMethodConfig(SofortTransaction::NAME, $sofortMId, $sofortSecretKey);
 $configCollection->add($sofortConfig);
 
 // The basic configuration requires the base URL for Wirecard and the username and password for the HTTP requests.

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -13,6 +13,6 @@ sonar.sources=src
 sonar.tests=test
 sonar.language=php
 sonar.coverage.exclusions=src/Exception/**,src/Transaction/Operation.php,src/Entity/MappableEntity.php,\
-  src/Response/FailureResponse.php
+  src/Response/FailureResponse.php,src/Transaction/Reservable.php
 
 sonar.php.coverage.reportPath=clover.xml

--- a/src/Transaction/SepaTransaction.php
+++ b/src/Transaction/SepaTransaction.php
@@ -109,14 +109,6 @@ class SepaTransaction extends Transaction implements Reservable
      */
     public function getConfigKey()
     {
-        return $this->retrievePaymentMethodName();
-    }
-
-    /**
-     * @return string
-     */
-    public function retrievePaymentMethodName()
-    {
         if (Operation::CREDIT === $this->operation || parent::TYPE_CREDIT == $this->parentTransactionType ||
             parent::TYPE_PENDING_CREDIT == $this->parentTransactionType) {
             return self::CREDIT_TRANSFER;
@@ -124,7 +116,6 @@ class SepaTransaction extends Transaction implements Reservable
 
         return self::DIRECT_DEBIT;
     }
-
 
     /**
      * @return mixed|string

--- a/src/Transaction/SofortTransaction.php
+++ b/src/Transaction/SofortTransaction.php
@@ -80,6 +80,24 @@ class SofortTransaction extends Transaction
     /**
      * @return string
      */
+    public function getConfigKey()
+    {
+        if (null !== $this->parentTransactionId) {
+            if (Operation::PAY === $this->operation) {
+                return SepaTransaction::DIRECT_DEBIT;
+            }
+            if (Operation::CREDIT === $this->operation) {
+                return SepaTransaction::CREDIT_TRANSFER;
+            }
+        }
+
+        return parent::getConfigKey();
+    }
+
+    /**
+     * @return string
+     * @throws \Wirecard\PaymentSdk\Exception\UnsupportedOperationException
+     */
     private function retrieveTransactionType()
     {
         $transactionTypes = [

--- a/src/Transaction/SofortTransaction.php
+++ b/src/Transaction/SofortTransaction.php
@@ -79,16 +79,19 @@ class SofortTransaction extends Transaction
 
     /**
      * @return string
+     * @throws \Wirecard\PaymentSdk\Exception\UnsupportedOperationException
      */
     public function getConfigKey()
     {
         if (null !== $this->parentTransactionId) {
-            if (Operation::PAY === $this->operation) {
-                return SepaTransaction::DIRECT_DEBIT;
+            switch ($this->operation) {
+                case Operation::PAY:
+                    return SepaTransaction::DIRECT_DEBIT;
+                case Operation::CREDIT:
+                    return SepaTransaction::CREDIT_TRANSFER;
             }
-            if (Operation::CREDIT === $this->operation) {
-                return SepaTransaction::CREDIT_TRANSFER;
-            }
+
+            throw new UnsupportedOperationException();
         }
 
         return parent::getConfigKey();

--- a/src/Transaction/ThreeDCreditCardTransaction.php
+++ b/src/Transaction/ThreeDCreditCardTransaction.php
@@ -41,7 +41,9 @@ use Wirecard\PaymentSdk\Exception\UnsupportedOperationException;
  */
 class ThreeDCreditCardTransaction extends CreditCardTransaction
 {
+    const NAME = '3dcreditcard';
     const TYPE_CHECK_ENROLLMENT = 'check-enrollment';
+
     /**
      * @var string
      */
@@ -173,5 +175,16 @@ class ThreeDCreditCardTransaction extends CreditCardTransaction
         }
 
         return $transactionType;
+    }
+
+    /**
+     * @return string
+     *
+     * For 3D transactions we have to use a different config,
+     * but we have to send the payment method name 'creditcard' to the Engine.
+     */
+    protected function paymentMethodNameForRequest()
+    {
+        return parent::NAME;
     }
 }

--- a/src/Transaction/Transaction.php
+++ b/src/Transaction/Transaction.php
@@ -164,7 +164,7 @@ abstract class Transaction
     public function mappedProperties()
     {
         $result = ['payment-methods' => ['payment-method' => [[
-            'name' => $this->retrievePaymentMethodName()
+            'name' => $this->paymentMethodNameForRequest()
         ]]]];
 
         if ($this->amount) {
@@ -208,14 +208,14 @@ abstract class Transaction
      */
     public function getConfigKey()
     {
-        return get_class($this);
+        return $this::NAME;
     }
 
     /**
      * @return string
      */
-    public function retrievePaymentMethodName()
+    protected function paymentMethodNameForRequest()
     {
-        return $this::NAME;
+        return $this->getConfigKey();
     }
 }

--- a/src/TransactionService.php
+++ b/src/TransactionService.php
@@ -209,7 +209,7 @@ class TransactionService
         $requestData = array(
             'request_time_stamp' => gmdate('YmdHis'),
             'request_id' => call_user_func($this->getRequestIdGenerator(), 64),
-            'merchant_account_id' => $this->getConfig()->get(CreditCardTransaction::class)->getMerchantAccountId(),
+            'merchant_account_id' => $this->getConfig()->get(CreditCardTransaction::NAME)->getMerchantAccountId(),
             'transaction_type' => 'tokenize',
             'requested_amount' => 0,
             'requested_amount_currency' => $this->getConfig()->getDefaultCurrency(),
@@ -225,7 +225,7 @@ class TransactionService
                 $requestData['transaction_type'] .
                 $requestData['requested_amount'] .
                 $requestData['requested_amount_currency'] .
-                $this->getConfig()->get(CreditCardTransaction::class)->getSecret()
+                $this->getConfig()->get(CreditCardTransaction::NAME)->getSecret()
             )
         );
 

--- a/test/Transaction/SepaTransactionUTest.php
+++ b/test/Transaction/SepaTransactionUTest.php
@@ -210,14 +210,12 @@ class SepaTransactionUTest extends \PHPUnit_Framework_TestCase
     public function testRetrievePaymentMethodNamePay()
     {
         $this->tx->setOperation(Operation::PAY);
-        $this->assertEquals(SepaTransaction::DIRECT_DEBIT, $this->tx->retrievePaymentMethodName());
         $this->assertEquals(SepaTransaction::DIRECT_DEBIT, $this->tx->getConfigKey());
     }
 
     public function testRetrievePaymentMethodNameCredit()
     {
         $this->tx->setOperation(Operation::CREDIT);
-        $this->assertEquals(SepaTransaction::CREDIT_TRANSFER, $this->tx->retrievePaymentMethodName());
         $this->assertEquals(SepaTransaction::CREDIT_TRANSFER, $this->tx->getConfigKey());
     }
 

--- a/test/Transaction/SofortTransactionUTest.php
+++ b/test/Transaction/SofortTransactionUTest.php
@@ -35,6 +35,7 @@ namespace WirecardTest\PaymentSdk\Transaction;
 use Wirecard\PaymentSdk\Entity\Money;
 use Wirecard\PaymentSdk\Entity\Redirect;
 use Wirecard\PaymentSdk\Transaction\Operation;
+use Wirecard\PaymentSdk\Transaction\SepaTransaction;
 use Wirecard\PaymentSdk\Transaction\SofortTransaction;
 
 class SofortTransactionUTest extends \PHPUnit_Framework_TestCase
@@ -91,5 +92,25 @@ class SofortTransactionUTest extends \PHPUnit_Framework_TestCase
         $result = $this->tx->mappedProperties();
 
         $this->assertEquals($expectedResult, $result);
+    }
+
+    public function testGetConfigKeySepaDD()
+    {
+        $this->tx->setParentTransactionId('anything');
+        $this->tx->setOperation(Operation::PAY);
+
+        $result = $this->tx->getConfigKey();
+
+        $this->assertEquals(SepaTransaction::DIRECT_DEBIT, $result);
+    }
+
+    public function testGetConfigKeySepaCT()
+    {
+        $this->tx->setParentTransactionId('anything');
+        $this->tx->setOperation(Operation::CREDIT);
+
+        $result = $this->tx->getConfigKey();
+
+        $this->assertEquals(SepaTransaction::CREDIT_TRANSFER, $result);
     }
 }

--- a/test/Transaction/SofortTransactionUTest.php
+++ b/test/Transaction/SofortTransactionUTest.php
@@ -113,4 +113,15 @@ class SofortTransactionUTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(SepaTransaction::CREDIT_TRANSFER, $result);
     }
+
+    /**
+     * @expectedException \Wirecard\PaymentSdk\Exception\UnsupportedOperationException
+     */
+    public function testGetConfigKeyInvalid()
+    {
+        $this->tx->setParentTransactionId('anything');
+        $this->tx->setOperation('invalid');
+
+        $this->tx->getConfigKey();
+    }
 }


### PR DESCRIPTION
During the implementation of payment with sofortbanking, it seemed to make sense to simplify the retrieving of config key and payment method name. The 2 can be the same most of the time with the only exception for 3D credit card transactions. These need a specific configuration, but have to use the same payment type as the SSL credit card transactions.

## The new structure
### getConfigKey
Default implementation: constant NAME
Custom implementations:
 - SEPA: DD or CT depending on operation and parent transaction type
 - Sofort: constant NAME, DD or CT depending on operation and parent transaction type

### paymentMethodNameForRequest
protected
Default implementation: getConfigKey()
Custom implementation:
 - 3D credit card: parent::NAME

## For the integrators
When creating a PaymentTypeConfig object:  
most of the time they have to pass XxxTransaction::NAME as the parameter config key.
Exception: SEPA configurations, where they have to pass:
 - SepaTransaction::DIRECT_DEBIT or 
 - SepaTransaction::CREDIT_TRANSFER
