### PR TITLE
CCard: mapping refactoring

### DIFF
--- a/src/Transaction/CreditCardTransaction.php
+++ b/src/Transaction/CreditCardTransaction.php
@@ -68,11 +68,7 @@ class CreditCardTransaction extends Transaction implements Reservable
      */
     protected function mappedSpecificProperties()
     {
-        if ($this->tokenId === null && ($this->parentTransactionId === null && get_class($this) === self::class)) {
-            throw new MandatoryFieldMissingException(
-                'At least one of these two parameters has to be provided: token ID, parent transaction ID.'
-            );
-        }
+        $this->validate();
 
         $result[self::PARAM_TRANSACTION_TYPE] = $this->retrieveTransactionType();
 
@@ -168,5 +164,18 @@ class CreditCardTransaction extends Transaction implements Reservable
         }
 
         return $transactionType;
+    }
+
+    /**
+     *
+     * @throws \Wirecard\PaymentSdk\Exception\MandatoryFieldMissingException
+     */
+    protected function validate()
+    {
+        if ($this->tokenId === null && $this->parentTransactionId === null) {
+            throw new MandatoryFieldMissingException(
+                'At least one of these two parameters has to be provided: token ID, parent transaction ID.'
+            );
+        }
     }
 }

--- a/src/Transaction/ThreeDCreditCardTransaction.php
+++ b/src/Transaction/ThreeDCreditCardTransaction.php
@@ -195,6 +195,4 @@ class ThreeDCreditCardTransaction extends CreditCardTransaction
     {
         // No validation necessary.
     }
-
-
 }

--- a/src/Transaction/ThreeDCreditCardTransaction.php
+++ b/src/Transaction/ThreeDCreditCardTransaction.php
@@ -187,4 +187,14 @@ class ThreeDCreditCardTransaction extends CreditCardTransaction
     {
         return parent::NAME;
     }
+
+    /**
+     *
+     */
+    protected function validate()
+    {
+        // No validation necessary.
+    }
+
+
 }

--- a/test/Transaction/CreditCardTransactionUTest.php
+++ b/test/Transaction/CreditCardTransactionUTest.php
@@ -56,4 +56,12 @@ class CreditCardTransactionUTest extends \PHPUnit_Framework_TestCase
         $this->tx->setOperation('non-existing');
         $this->tx->mappedProperties();
     }
+
+    /**
+     * @expectedException \Wirecard\PaymentSdk\Exception\MandatoryFieldMissingException
+     */
+    public function testMapPropertiesNoTokenIdNoParentTransactionId()
+    {
+        $this->tx->mappedProperties();
+    }
 }

--- a/test/Transaction/ThreeDCreditCardTransactionUTest.php
+++ b/test/Transaction/ThreeDCreditCardTransactionUTest.php
@@ -39,35 +39,35 @@ class ThreeDCreditCardTransactionUTest extends \PHPUnit_Framework_TestCase
     /**
      * @var ThreeDCreditCardTransaction
      */
-    private $instance;
+    private $tx;
 
     public function setUp()
     {
-        $this->instance = new ThreeDCreditCardTransaction();
+        $this->tx = new ThreeDCreditCardTransaction();
     }
 
     public function testSetTermUrl()
     {
-        $this->instance->setTermUrl('test');
-        $this->assertAttributeEquals('test', 'termUrl', $this->instance);
+        $this->tx->setTermUrl('test');
+        $this->assertAttributeEquals('test', 'termUrl', $this->tx);
     }
 
     public function testGetTermUrl()
     {
-        $this->instance->setTermUrl('test');
-        $this->assertEquals('test', $this->instance->getTermUrl());
+        $this->tx->setTermUrl('test');
+        $this->assertEquals('test', $this->tx->getTermUrl());
     }
 
     public function testSetPaRes()
     {
-        $this->instance->setPaRes('paRes');
-        $this->assertAttributeEquals('paRes', 'paRes', $this->instance);
+        $this->tx->setPaRes('paRes');
+        $this->assertAttributeEquals('paRes', 'paRes', $this->tx);
     }
 
     public function testGetPaRes()
     {
-        $this->instance->setPaRes('paRes');
-        $this->assertEquals('paRes', $this->instance->getPaRes());
+        $this->tx->setPaRes('paRes');
+        $this->assertEquals('paRes', $this->tx->getPaRes());
     }
 
     public function testMappedPropertiesDefault()
@@ -82,13 +82,13 @@ class ThreeDCreditCardTransactionUTest extends \PHPUnit_Framework_TestCase
             ],
             'transaction-type' => 'check-enrollment'
         ];
-        $this->instance->setOperation(Operation::RESERVE);
-        $this->assertEquals($valid, $this->instance->mappedProperties());
+        $this->tx->setOperation(Operation::RESERVE);
+        $this->assertEquals($valid, $this->tx->mappedProperties());
     }
 
     public function testMappedPropertiesPares()
     {
-        $this->instance->setPaRes('pasdsgf');
+        $this->tx->setPaRes('pasdsgf');
 
         $valid = [
             'payment-methods' => [
@@ -103,7 +103,7 @@ class ThreeDCreditCardTransactionUTest extends \PHPUnit_Framework_TestCase
                 'pares' => 'pasdsgf'
             ]
         ];
-        $this->instance->setOperation('testtype');
-        $this->assertEquals($valid, $this->instance->mappedProperties());
+        $this->tx->setOperation('testtype');
+        $this->assertEquals($valid, $this->tx->mappedProperties());
     }
 }


### PR DESCRIPTION
Replaced get_class($this) === self::class with an overridden method.

Should we add some validation to the ThreeDCreditCardTransaction class also?
E.g.
 - tokenId or
 - parentTransactionId or
 - paRes
is required?