### PR TITLE
Config: added the possibility of fallback

### DIFF
--- a/examples/Sepa/cancel.php
+++ b/examples/Sepa/cancel.php
@@ -26,16 +26,14 @@ $httpPass = 'qD2wzQ_hrc!8';
 $config = new Config\Config($baseUrl, $httpUser, $httpPass, 'EUR');
 
 // #### SEPA configuration
-// Create and add a configuration object with the settings for SEPA direct debit.
+// Create and add a configuration object with the settings for SEPA.
+// If you have separate configurations for SEPA direct debit and SEPA credit transfer,
+// create two PaymentMethodConfig objects
+// with the keys SepaTransaction::DIRECT_DEBIT and SepaTransaction::CREDIT_TRANSFER respectively.
 $sepaMId = '4c901196-eff7-411e-82a3-5ef6b6860d64';
 $sepaKey = 'ecdf5990-0372-47cd-a55d-037dccfe9d25';
-$sepaDdConfig = new Config\PaymentMethodConfig(SepaTransaction::DIRECT_DEBIT, $sepaMId, $sepaKey);
-$config->add($sepaDdConfig);
-
-// The configration for sepa needs to be also added with the corresponding transaction for credit transfer.
-$sepaCtConfig = new Config\PaymentMethodConfig(SepaTransaction::CREDIT_TRANSFER, $sepaMId, $sepaKey);
-$config->add($sepaCtConfig);
-
+$sepaConfig = new Config\PaymentMethodConfig(SepaTransaction::NAME, $sepaMId, $sepaKey);
+$config->add($sepaConfig);
 
 // The _TransactionService_ is used to execute the cancel operation.
 $transactionService = new TransactionService($config);

--- a/examples/Sepa/credit.php
+++ b/examples/Sepa/credit.php
@@ -38,8 +38,8 @@ $config = new Config\Config($baseUrl, $httpUser, $httpPass, 'EUR');
 // Create and add a configuration object with the settings for SEPA
 $sepaMId = '4c901196-eff7-411e-82a3-5ef6b6860d64';
 $sepaKey = 'ecdf5990-0372-47cd-a55d-037dccfe9d25';
-$sepaCtConfig = new Config\PaymentMethodConfig(SepaTransaction::CREDIT_TRANSFER, $sepaMId, $sepaKey);
-$config->add($sepaCtConfig);
+$sepaConfig = new Config\PaymentMethodConfig(SepaTransaction::NAME, $sepaMId, $sepaKey);
+$config->add($sepaConfig);
 
 // ## Transaction
 

--- a/examples/Sepa/pay.php
+++ b/examples/Sepa/pay.php
@@ -40,11 +40,11 @@ $config = new Config\Config($baseUrl, $httpUser, $httpPass, 'EUR');
 // Create and add a configuration object with the settings for SEPA.
 $sepaMId = '4c901196-eff7-411e-82a3-5ef6b6860d64';
 $sepaKey = 'ecdf5990-0372-47cd-a55d-037dccfe9d25';
-$sepaDdConfig = new Config\SepaConfig(SepaTransaction::DIRECT_DEBIT, $sepaMId, $sepaKey);
+$sepaConfig = new Config\SepaConfig(SepaTransaction::NAME, $sepaMId, $sepaKey);
 
 // In order to execute a pay transaction you also have to provide your creditor ID.
-$sepaDdConfig->setCreditorId('DE98ZZZ09999999999');
-$config->add($sepaDdConfig);
+$sepaConfig->setCreditorId('DE98ZZZ09999999999');
+$config->add($sepaConfig);
 
 
 // ## Transaction

--- a/examples/Sepa/reserve.php
+++ b/examples/Sepa/reserve.php
@@ -34,11 +34,11 @@ $config = new Config\Config($baseUrl, $httpUser, $httpPass, 'EUR');
 // Create and add a configuration object with the settings for SEPA.
 $sepaMId = '4c901196-eff7-411e-82a3-5ef6b6860d64';
 $sepaKey = 'ecdf5990-0372-47cd-a55d-037dccfe9d25';
-$sepaDdConfig = new Config\SepaConfig(SepaTransaction::DIRECT_DEBIT, $sepaMId, $sepaKey);
+$sepaConfig = new Config\SepaConfig(SepaTransaction::NAME, $sepaMId, $sepaKey);
 
 // In order to execute a pay transaction you also have to provide your creditor ID.
-$sepaDdConfig->setCreditorId('DE98ZZZ09999999999');
-$config->add($sepaDdConfig);
+$sepaConfig->setCreditorId('DE98ZZZ09999999999');
+$config->add($sepaConfig);
 
 
 // ## Transaction

--- a/src/Exception/UnconfiguredPaymentMethodException.php
+++ b/src/Exception/UnconfiguredPaymentMethodException.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Shop System Plugins - Terms of Use
+ *
+ * The plugins offered are provided free of charge by Wirecard Central Eastern Europe GmbH
+ * (abbreviated to Wirecard CEE) and are explicitly not part of the Wirecard CEE range of
+ * products and services.
+ *
+ * They have been tested and approved for full functionality in the standard configuration
+ * (status on delivery) of the corresponding shop system. They are under General Public
+ * License Version 3 (GPLv3) and can be used, developed and passed on to third parties under
+ * the same terms.
+ *
+ * However, Wirecard CEE does not provide any guarantee or accept any liability for any errors
+ * occurring when used in an enhanced, customized shop system configuration.
+ *
+ * Operation in an enhanced, customized configuration is at your own risk and requires a
+ * comprehensive test phase by the user of the plugin.
+ *
+ * Customers use the plugins at their own risk. Wirecard CEE does not guarantee their full
+ * functionality neither does Wirecard CEE assume liability for any disadvantages related to
+ * the use of the plugins. Additionally, Wirecard CEE does not guarantee the full functionality
+ * for customized shop systems or installed plugins of other vendors of plugins within the same
+ * shop system.
+ *
+ * Customers are responsible for testing the plugin's functionality before starting productive
+ * operation.
+ *
+ * By installing the plugin into the shop system the customer agrees to these terms of use.
+ * Please do not use the plugin if you do not agree to these terms of use!
+ */
+
+namespace Wirecard\PaymentSdk\Exception;
+
+/**
+ * Class UnconfiguredPaymentMethodException
+ * @package Wirecard\PaymentSdk\Exception
+ */
+class UnconfiguredPaymentMethodException extends \UnexpectedValueException
+{
+
+}

--- a/src/Transaction/SepaTransaction.php
+++ b/src/Transaction/SepaTransaction.php
@@ -37,6 +37,7 @@ use Wirecard\PaymentSdk\Exception\UnsupportedOperationException;
 
 class SepaTransaction extends Transaction implements Reservable
 {
+    const NAME = 'sepa';
     const DIRECT_DEBIT = 'sepadirectdebit';
     const CREDIT_TRANSFER = 'sepacredit';
 

--- a/src/Transaction/Transaction.php
+++ b/src/Transaction/Transaction.php
@@ -45,7 +45,7 @@ abstract class Transaction
     const PARAM_TRANSACTION_TYPE = 'transaction-type';
     const PARAM_PARENT_TRANSACTION_ID = 'parent-transaction-id';
     const ENDPOINT = '/engine/rest/paymentmethods/';
-    const NAME = '';
+    const NAME = 'sepa';
     const TYPE_AUTHORIZATION = 'authorization';
     const TYPE_REFERENCED_AUTHORIZATION = 'referenced-authorization';
     const TYPE_CAPTURE_AUTHORIZATION = 'capture-authorization';

--- a/src/Transaction/Transaction.php
+++ b/src/Transaction/Transaction.php
@@ -45,7 +45,7 @@ abstract class Transaction
     const PARAM_TRANSACTION_TYPE = 'transaction-type';
     const PARAM_PARENT_TRANSACTION_ID = 'parent-transaction-id';
     const ENDPOINT = '/engine/rest/paymentmethods/';
-    const NAME = 'sepa';
+    const NAME = '';
     const TYPE_AUTHORIZATION = 'authorization';
     const TYPE_REFERENCED_AUTHORIZATION = 'referenced-authorization';
     const TYPE_CAPTURE_AUTHORIZATION = 'capture-authorization';

--- a/test/Config/ConfigUTest.php
+++ b/test/Config/ConfigUTest.php
@@ -112,6 +112,17 @@ class ConfigUTest extends \PHPUnit_Framework_TestCase
         $this->config->get('unknown_payment_method');
     }
 
+    /**
+     * @expectedException \Wirecard\PaymentSdk\Exception\UnconfiguredPaymentMethodException
+     */
+    public function testGetUnknownPaymentMethodBecauseFallbackAlsoUnknown()
+    {
+        $payPalConfig = new PaymentMethodConfig(PayPalTransaction::NAME, 'mid', 'key');
+        $this->config->add($payPalConfig);
+
+        $this->config->get(SepaTransaction::DIRECT_DEBIT);
+    }
+
     public function testSetDefaultCurrency()
     {
         $this->config = new Config(

--- a/test/Config/ConfigUTest.php
+++ b/test/Config/ConfigUTest.php
@@ -35,6 +35,7 @@ namespace WirecardTest\PaymentSdk\Config;
 use Wirecard\PaymentSdk\Config\Config;
 use Wirecard\PaymentSdk\Config\PaymentMethodConfig;
 use Wirecard\PaymentSdk\Transaction\PayPalTransaction;
+use Wirecard\PaymentSdk\Transaction\SepaTransaction;
 
 class ConfigUTest extends \PHPUnit_Framework_TestCase
 {
@@ -72,12 +73,32 @@ class ConfigUTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('EUR', $this->instance->getDefaultCurrency());
     }
 
-    public function testAddAndGet()
+    public function testGetStraightforwardCase()
     {
         $payPalConfig = new PaymentMethodConfig(PayPalTransaction::NAME, 'mid', 'key');
         $this->instance->add($payPalConfig);
 
         $this->assertEquals($payPalConfig, $this->instance->get(PayPalTransaction::NAME));
+    }
+
+    public function testGetFallback()
+    {
+        $sepaConfig = new PaymentMethodConfig(SepaTransaction::NAME, 'mid', 'key');
+        $this->instance->add($sepaConfig);
+
+        $this->assertEquals($sepaConfig, $this->instance->get(SepaTransaction::DIRECT_DEBIT));
+        $this->assertEquals($sepaConfig, $this->instance->get(SepaTransaction::CREDIT_TRANSFER));
+    }
+
+    /**
+     * @expectedException \Wirecard\PaymentSdk\Exception\UnconfiguredPaymentMethodException
+     */
+    public function testGetUnknownPaymentMethod()
+    {
+        $payPalConfig = new PaymentMethodConfig(PayPalTransaction::NAME, 'mid', 'key');
+        $this->instance->add($payPalConfig);
+
+        $this->instance->get('unknown_payment_method');
     }
 
     public function testSetDefaultCurrency()

--- a/test/Config/ConfigUTest.php
+++ b/test/Config/ConfigUTest.php
@@ -42,11 +42,11 @@ class ConfigUTest extends \PHPUnit_Framework_TestCase
     /**
      * @var Config
      */
-    private $instance;
+    private $config;
 
     public function setUp()
     {
-        $this->instance = new Config(
+        $this->config = new Config(
             'http://www.example.com',
             'httpUser',
             'httpPassword'
@@ -55,39 +55,50 @@ class ConfigUTest extends \PHPUnit_Framework_TestCase
 
     public function testGetBaseUrl()
     {
-        $this->assertEquals('http://www.example.com', $this->instance->getBaseUrl());
+        $this->assertEquals('http://www.example.com', $this->config->getBaseUrl());
     }
 
     public function testGetHttpUser()
     {
-        $this->assertEquals('httpUser', $this->instance->getHttpUser());
+        $this->assertEquals('httpUser', $this->config->getHttpUser());
     }
 
     public function testGetHttpPassword()
     {
-        $this->assertEquals('httpPassword', $this->instance->getHttpPassword());
+        $this->assertEquals('httpPassword', $this->config->getHttpPassword());
     }
 
     public function testGetDefaultCurrency()
     {
-        $this->assertEquals('EUR', $this->instance->getDefaultCurrency());
+        $this->assertEquals('EUR', $this->config->getDefaultCurrency());
     }
 
     public function testGetStraightforwardCase()
     {
         $payPalConfig = new PaymentMethodConfig(PayPalTransaction::NAME, 'mid', 'key');
-        $this->instance->add($payPalConfig);
+        $this->config->add($payPalConfig);
 
-        $this->assertEquals($payPalConfig, $this->instance->get(PayPalTransaction::NAME));
+        $this->assertEquals($payPalConfig, $this->config->get(PayPalTransaction::NAME));
     }
 
     public function testGetFallback()
     {
         $sepaConfig = new PaymentMethodConfig(SepaTransaction::NAME, 'mid', 'key');
-        $this->instance->add($sepaConfig);
+        $this->config->add($sepaConfig);
 
-        $this->assertEquals($sepaConfig, $this->instance->get(SepaTransaction::DIRECT_DEBIT));
-        $this->assertEquals($sepaConfig, $this->instance->get(SepaTransaction::CREDIT_TRANSFER));
+        $this->assertEquals($sepaConfig, $this->config->get(SepaTransaction::DIRECT_DEBIT));
+        $this->assertEquals($sepaConfig, $this->config->get(SepaTransaction::CREDIT_TRANSFER));
+    }
+
+    public function testGetUseSpecificIfExistsAndNotFallback()
+    {
+        $sepaConfig = new PaymentMethodConfig(SepaTransaction::NAME, 'mid', 'key');
+        $ddConfig = new PaymentMethodConfig(SepaTransaction::DIRECT_DEBIT, 'dd_mid', 'other_key');
+        $this->config->add($sepaConfig);
+        $this->config->add($ddConfig);
+
+        $this->assertEquals($ddConfig, $this->config->get(SepaTransaction::DIRECT_DEBIT));
+        $this->assertEquals($sepaConfig, $this->config->get(SepaTransaction::CREDIT_TRANSFER));
     }
 
     /**
@@ -96,20 +107,20 @@ class ConfigUTest extends \PHPUnit_Framework_TestCase
     public function testGetUnknownPaymentMethod()
     {
         $payPalConfig = new PaymentMethodConfig(PayPalTransaction::NAME, 'mid', 'key');
-        $this->instance->add($payPalConfig);
+        $this->config->add($payPalConfig);
 
-        $this->instance->get('unknown_payment_method');
+        $this->config->get('unknown_payment_method');
     }
 
     public function testSetDefaultCurrency()
     {
-        $this->instance = new Config(
+        $this->config = new Config(
             'http://www.example.com',
             'httpUser',
             'httpPassword',
             'USD'
         );
 
-        $this->assertEquals('USD', $this->instance->getDefaultCurrency());
+        $this->assertEquals('USD', $this->config->getDefaultCurrency());
     }
 }


### PR DESCRIPTION
So that the integrators don't have to add SEPA DD and SEPA CT configurations separately.
Both of them refer to the fallback configuration with the key 'sepa'.