### PR TITLE
SepaConfig: added default value for the payment method name

### DIFF
--- a/examples/Sepa/pay.php
+++ b/examples/Sepa/pay.php
@@ -40,9 +40,9 @@ $config = new Config\Config($baseUrl, $httpUser, $httpPass, 'EUR');
 // Create and add a configuration object with the settings for SEPA.
 $sepaMId = '4c901196-eff7-411e-82a3-5ef6b6860d64';
 $sepaKey = 'ecdf5990-0372-47cd-a55d-037dccfe9d25';
-$sepaConfig = new Config\SepaConfig(SepaTransaction::NAME, $sepaMId, $sepaKey);
-
 // In order to execute a pay transaction you also have to provide your creditor ID.
+// For this reason we have to use a specific SepaConfig object.
+$sepaConfig = new Config\SepaConfig($sepaMId, $sepaKey);
 $sepaConfig->setCreditorId('DE98ZZZ09999999999');
 $config->add($sepaConfig);
 

--- a/examples/Sepa/reserve.php
+++ b/examples/Sepa/reserve.php
@@ -34,10 +34,8 @@ $config = new Config\Config($baseUrl, $httpUser, $httpPass, 'EUR');
 // Create and add a configuration object with the settings for SEPA.
 $sepaMId = '4c901196-eff7-411e-82a3-5ef6b6860d64';
 $sepaKey = 'ecdf5990-0372-47cd-a55d-037dccfe9d25';
-$sepaConfig = new Config\SepaConfig(SepaTransaction::NAME, $sepaMId, $sepaKey);
-
-// In order to execute a pay transaction you also have to provide your creditor ID.
-$sepaConfig->setCreditorId('DE98ZZZ09999999999');
+// For reserve transactions you can use a PaymentConfig object or a SepaConfig object as well.
+$sepaConfig = new Config\SepaConfig($sepaMId, $sepaKey);
 $config->add($sepaConfig);
 
 

--- a/src/Config/PaymentMethodConfig.php
+++ b/src/Config/PaymentMethodConfig.php
@@ -38,7 +38,7 @@ class PaymentMethodConfig implements MappableEntity
     /**
      * @var string
      */
-    private $paymentMethodName;
+    protected $paymentMethodName;
 
     /**
      * @var string

--- a/src/Config/SepaConfig.php
+++ b/src/Config/SepaConfig.php
@@ -32,6 +32,8 @@
 
 namespace Wirecard\PaymentSdk\Config;
 
+use Wirecard\PaymentSdk\Transaction\SepaTransaction;
+
 class SepaConfig extends PaymentMethodConfig
 {
     /**
@@ -40,11 +42,29 @@ class SepaConfig extends PaymentMethodConfig
     private $creditorId;
 
     /**
+     * SepaConfig constructor.
+     * @param string $merchantAccountId
+     * @param string $secret
+     */
+    public function __construct($merchantAccountId, $secret)
+    {
+        parent::__construct(SepaTransaction::NAME, $merchantAccountId, $secret);
+    }
+
+    /**
      * @param string $creditorId
      */
     public function setCreditorId($creditorId)
     {
         $this->creditorId = $creditorId;
+    }
+
+    /**
+     * @param string $paymentMethodName
+     */
+    public function setPaymentMethodName($paymentMethodName)
+    {
+        $this->paymentMethodName = $paymentMethodName;
     }
 
     public function mappedProperties()

--- a/test/Config/SepaConfigUTest.php
+++ b/test/Config/SepaConfigUTest.php
@@ -37,11 +37,25 @@ use Wirecard\PaymentSdk\Transaction\SepaTransaction;
 
 class SepaConfigUTest extends \PHPUnit_Framework_TestCase
 {
+    public function testDefaultPaymentMethodName()
+    {
+        $conf = new SepaConfig('accountId', 'secret');
+
+        $this->assertEquals(SepaTransaction::NAME, $conf->getPaymentMethodName());
+    }
+
+    public function testSetPaymentMethodName()
+    {
+        $conf = new SepaConfig('accountId', 'secret');
+        $conf->setPaymentMethodName(SepaTransaction::CREDIT_TRANSFER);
+
+        $this->assertEquals(SepaTransaction::CREDIT_TRANSFER, $conf->getPaymentMethodName());
+    }
 
     public function testMappedProperties()
     {
         $accountId = 'accountId';
-        $conf = new SepaConfig(SepaTransaction::DIRECT_DEBIT, $accountId, 'secret');
+        $conf = new SepaConfig($accountId, 'secret');
         $creditorId = '555-cred-id';
         $conf->setCreditorId($creditorId);
 


### PR DESCRIPTION
## SepaConfig class
 - added custom constructor with only 2 parameters: merchant account ID, key. The payment method name  is set to the default value 'sepa'.
 - a setter to set a custom payment method name

## Examples
### reserve
 - Removed surplus parameter creditor ID.
 - Added comment.
### pay
 - Added comment that you have to use the custom SepaConfig class.
