### PR TITLE
TransactionService dependencies: small refactoring

### DIFF
--- a/examples/Sofort/return.php
+++ b/examples/Sofort/return.php
@@ -5,6 +5,7 @@
 // ## Required objects
 // To include the necessary files, we use the composer for PSR-4 autoloading.
 require __DIR__ . '/../../vendor/autoload.php';
+require __DIR__ . '/../inc/common.php';
 
 use Wirecard\PaymentSdk\Config;
 use Wirecard\PaymentSdk\Config\PaymentMethodConfig;

--- a/test/TransactionServiceUTest.php
+++ b/test/TransactionServiceUTest.php
@@ -451,6 +451,23 @@ class TransactionServiceUTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($successResponse, $result);
     }
 
+    public function testRequestIdRandomness()
+    {
+        $bindHelper = function () {
+            return $this->requestIdGenerator;
+        };
+
+        $bound = $bindHelper->bindTo($this->instance, $this->instance);
+
+        $requestId = call_user_func($bound());
+        usleep(1);
+        $laterRequestId = call_user_func($bound());
+
+        $this->assertTrue(is_string($requestId));
+        $this->assertTrue(is_string($laterRequestId));
+        $this->assertNotEquals($requestId, $laterRequestId);
+    }
+
     /**
      * @param $tx
      * @return SuccessResponse

--- a/test/TransactionServiceUTest.php
+++ b/test/TransactionServiceUTest.php
@@ -126,50 +126,6 @@ class TransactionServiceUTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('\Psr\Log\LoggerInterface', $method());
     }
 
-    public function testGetHttpClient()
-    {
-        $helper = function () {
-            return $this->getHttpClient();
-        };
-
-        $method = $helper->bindTo($this->instance, $this->instance);
-
-        $this->assertInstanceOf('\GuzzleHttp\Client', $method());
-    }
-
-    public function testGetRequestMapper()
-    {
-        $helper = function () {
-            return $this->getRequestMapper();
-        };
-
-        $method = $helper->bindTo($this->instance, $this->instance);
-
-        $this->assertInstanceOf('\Wirecard\PaymentSdk\Mapper\RequestMapper', $method());
-    }
-
-    public function testGetResponseMapper()
-    {
-        $helper = function () {
-            return $this->getResponseMapper();
-        };
-
-        $method = $helper->bindTo($this->instance, $this->instance);
-
-        $this->assertInstanceOf('\Wirecard\PaymentSdk\Mapper\ResponseMapper', $method());
-    }
-
-    public function testGetRequestIdGenerator()
-    {
-        $helper = function () {
-            return $this->getRequestIdGenerator();
-        };
-
-        $method = $helper->bindTo($this->instance, $this->instance);
-
-        $this->assertInstanceOf('Closure', $method());
-    }
-
     /**
      * @param $response
      * @param $class
@@ -493,18 +449,6 @@ class TransactionServiceUTest extends \PHPUnit_Framework_TestCase
         $result = $this->instance->credit($tx);
 
         $this->assertEquals($successResponse, $result);
-    }
-
-
-    public function testRequestIdGeneratorRandomness()
-    {
-        $this->instance = new TransactionService($this->config, null, null, null, null, null);
-
-        $requestId = call_user_func($this->instance->getRequestIdGenerator());
-        usleep(1);
-        $laterRequestId = call_user_func($this->instance->getRequestIdGenerator());
-
-        $this->assertNotEquals($requestId, $laterRequestId);
     }
 
     /**


### PR DESCRIPTION
Description
------------
Removed the singleton-style getter method.
The dependencies are now initialized in the constructor.

Reasons
---------
 - less code
 - avoiding self-encapsulation

In order to execute a public method, almost all of these dependencies are necessary. If we have to instantiate all dependencies anyway, we can do it in the constructor.
The singleton-style getter methods make sense, if the dependency isn't used everywhere.

Question
----------
With this change the unit test for the method getRequestIdGenerator also disappeared.
Should we test the randomness of the request ID somewhere else?
