### PR TITLE
Remove param operation

### DIFF
--- a/src/Transaction/CreditCardTransaction.php
+++ b/src/Transaction/CreditCardTransaction.php
@@ -169,4 +169,9 @@ class CreditCardTransaction extends Transaction implements Reservable
     {
         return self::TYPE_CREDIT;
     }
+
+    public function retrieveOperationType()
+    {
+        return ($this->operation === Operation::RESERVE) ? self::TYPE_AUTHORIZATION : self::TYPE_PURCHASE;
+    }
 }

--- a/src/TransactionService.php
+++ b/src/TransactionService.php
@@ -369,7 +369,7 @@ class TransactionService
         $responseContent = $this->sendPostRequest($endpoint, $requestBody);
 
         $data = $transaction instanceof ThreeDCreditCardTransaction ? $transaction : null;
-        return $this->responseMapper->map($responseContent, $operation, $data);
+        return $this->responseMapper->map($responseContent, $data);
     }
 
     /**

--- a/test/Mapper/ResponseMapperUTest.php
+++ b/test/Mapper/ResponseMapperUTest.php
@@ -224,7 +224,7 @@ class ResponseMapperUTest extends \PHPUnit_Framework_TestCase
         /**
          * @var FormInteractionResponse $mapped
          */
-        $mapped = $this->mapper->map($payload, Operation::RESERVE, $transaction);
+        $mapped = $this->mapper->map($payload, $transaction);
 
         $this->assertInstanceOf(FormInteractionResponse::class, $mapped);
         $this->assertEquals($payload, $mapped->getRawData());
@@ -251,11 +251,12 @@ class ResponseMapperUTest extends \PHPUnit_Framework_TestCase
                         </three-d>
                     </payment>')->asXML();
         $transaction = new ThreeDCreditCardTransaction();
+        $transaction->setOperation(Operation::RESERVE);
 
         /**
          * @var FormInteractionResponse $mapped
          */
-        $mapped = $this->mapper->map($payload, Operation::RESERVE, $transaction);
+        $mapped = $this->mapper->map($payload, $transaction);
 
         $this->assertInstanceOf(FormInteractionResponse::class, $mapped);
         $this->assertEquals($payload, $mapped->getRawData());
@@ -291,7 +292,7 @@ class ResponseMapperUTest extends \PHPUnit_Framework_TestCase
         /**
          * @var FormInteractionResponse $mapped
          */
-        $mapped = $this->mapper->map($payload, Operation::RESERVE, $transaction);
+        $mapped = $this->mapper->map($payload, $transaction);
 
         $this->assertInstanceOf(FormInteractionResponse::class, $mapped);
         $this->assertEquals('dummy URL', $mapped->getFormFields()->getIterator()['TermUrl']);
@@ -313,12 +314,8 @@ class ResponseMapperUTest extends \PHPUnit_Framework_TestCase
                         </statuses>
                         <card-token></card-token>
                     </payment>')->asXML();
-        $transaction = new CreditCardTransaction();
 
-        /**
-         * @var FormInteractionResponse $mapped
-         */
-        $mapped = $this->mapper->map($payload, $transaction);
+        $mapped = $this->mapper->map($payload);
 
         $this->assertInstanceOf(SuccessResponse::class, $mapped);
         $this->assertEquals($payload, $mapped->getRawData());
@@ -726,7 +723,7 @@ class ResponseMapperUTest extends \PHPUnit_Framework_TestCase
                     </payment>';
         $transaction = new ThreeDCreditCardTransaction();
 
-        $this->mapper->map($payload, Operation::RESERVE, $transaction);
+        $this->mapper->map($payload, $transaction);
     }
 
 
@@ -755,7 +752,7 @@ class ResponseMapperUTest extends \PHPUnit_Framework_TestCase
                     </payment>';
         $transaction = new ThreeDCreditCardTransaction();
 
-        $this->mapper->map($payload, Operation::RESERVE, $transaction);
+        $this->mapper->map($payload, $transaction);
     }
 
     /**
@@ -783,10 +780,8 @@ class ResponseMapperUTest extends \PHPUnit_Framework_TestCase
                     </payment>';
         $transaction = new ThreeDCreditCardTransaction();
 
-        $this->mapper->map($payload, Operation::RESERVE, $transaction);
+        $this->mapper->map($payload, $transaction);
     }
-
-
 
     public function malformedResponseProvider()
     {

--- a/test/Transaction/CreditCardTransactionUTest.php
+++ b/test/Transaction/CreditCardTransactionUTest.php
@@ -302,4 +302,20 @@ class CreditCardTransactionUTest extends \PHPUnit_Framework_TestCase
         ];
         $this->assertEquals($expectedResult, $result);
     }
+
+    public function testRetrieveOperationTypeAuthorization()
+    {
+        $tx = new CreditCardTransaction();
+        $tx->setOperation(Operation::RESERVE);
+
+        $this->assertEquals(Transaction::TYPE_AUTHORIZATION, $tx->retrieveOperationType());
+    }
+
+    public function testRetrieveOperationTypePurchase()
+    {
+        $tx = new CreditCardTransaction();
+        $tx->setOperation(Operation::PAY);
+
+        $this->assertEquals(CreditCardTransaction::TYPE_PURCHASE, $tx->retrieveOperationType());
+    }
 }


### PR DESCRIPTION
Removed the parameter operation from the function ResponseMapper->map and several further functions in the call chain.
This is possible, because an earlier refactoring has defined the operation as a field of the transaction  
=> The Transaction class can contain the logic to "calculate" the operation type.

I'm still not that happy with the function CreditCardTransaction->retrieveOperationType.  
What it does, seems to be actually a mapping between our and Engine's operation terminology.
