### PR TITLE
Renamed Money class to Amount

### DIFF
--- a/examples/CreditCard/3d-pay.php
+++ b/examples/CreditCard/3d-pay.php
@@ -10,7 +10,7 @@ require __DIR__ . '/../../vendor/autoload.php';
 require __DIR__ . '/../inc/common.php';
 
 use Wirecard\PaymentSdk\Config;
-use Wirecard\PaymentSdk\Entity\Money;
+use Wirecard\PaymentSdk\Entity\Amount;
 use Wirecard\PaymentSdk\Response\FailureResponse;
 use Wirecard\PaymentSdk\Response\FormInteractionResponse;
 use Wirecard\PaymentSdk\Response\SuccessResponse;
@@ -37,8 +37,8 @@ $ccard3dConfig = new Config\PaymentMethodConfig(ThreeDCreditCardTransaction::NAM
 $config->add($ccard3dConfig);
 
 // ### Transaction related objects
-// Create a money object as amount which has to be payed by the consumer.
-$amount = new Money(12.59, 'EUR');
+// Create a amount object as amount which has to be payed by the consumer.
+$amount = new Amount(12.59, 'EUR');
 
 // If there was a previous transaction, use the ID of this parent transaction as reference.
 $parentTransactionId = array_key_exists('parentTransactionId', $_POST) ? $_POST['parentTransactionId'] : null;

--- a/examples/CreditCard/3d-reserve.php
+++ b/examples/CreditCard/3d-reserve.php
@@ -10,7 +10,7 @@ require __DIR__ . '/../../vendor/autoload.php';
 require __DIR__ . '/../inc/common.php';
 
 use Wirecard\PaymentSdk\Config;
-use Wirecard\PaymentSdk\Entity\Money;
+use Wirecard\PaymentSdk\Entity\Amount;
 use Wirecard\PaymentSdk\Response\FailureResponse;
 use Wirecard\PaymentSdk\Response\FormInteractionResponse;
 use Wirecard\PaymentSdk\Transaction\ThreeDCreditCardTransaction;
@@ -37,8 +37,8 @@ $ccard3dConfig = new Config\PaymentMethodConfig(ThreeDCreditCardTransaction::NAM
 $config->add($ccard3dConfig);
 
 // ### Transaction related objects
-// Create a money object as amount which has to be payed by the consumer.
-$amount = new Money(12.59, 'EUR');
+// Create a amount object as amount which has to be payed by the consumer.
+$amount = new Amount(12.59, 'EUR');
 
 // Tokens from a successful _seamlessRenderForm_ callback can be used to execute reservations.
 // If no token ID is provided, a predefined ID is used.

--- a/examples/CreditCard/credit.php
+++ b/examples/CreditCard/credit.php
@@ -10,7 +10,7 @@ require __DIR__ . '/../inc/common.php';
 
 use Wirecard\PaymentSdk\Config;
 use Wirecard\PaymentSdk\Entity\AccountHolder;
-use Wirecard\PaymentSdk\Entity\Money;
+use Wirecard\PaymentSdk\Entity\Amount;
 use Wirecard\PaymentSdk\Response\FailureResponse;
 use Wirecard\PaymentSdk\Response\SuccessResponse;
 use Wirecard\PaymentSdk\Transaction\CreditCardTransaction;
@@ -38,8 +38,8 @@ $ccardConfig = new Config\PaymentMethodConfig(CreditCardTransaction::NAME, $ccar
 $config->add($ccardConfig);
 
 // ### Transaction related objects
-// Create a money object as amount which has to be payed by the consumer.
-$amount = new Money(10.59, 'EUR');
+// Create a amount object as amount which has to be payed by the consumer.
+$amount = new Amount(10.59, 'EUR');
 
 // The account holder last name is required for credit.
 $accountHolder = new AccountHolder();

--- a/examples/CreditCard/pay-based-on-reserve.php
+++ b/examples/CreditCard/pay-based-on-reserve.php
@@ -48,7 +48,7 @@ if ('3d' === $_POST['transaction-type']) {
 }
 $transaction->setParentTransactionId($_POST['parentTransactionId']);
 if (array_key_exists('amount', $_POST)) {
-    $transaction->setAmount(new \Wirecard\PaymentSdk\Entity\Money((float)$_POST['amount'], 'EUR'));
+    $transaction->setAmount(new \Wirecard\PaymentSdk\Entity\Amount((float)$_POST['amount'], 'EUR'));
 }
 
 // ### Transaction Service

--- a/examples/CreditCard/ssl-pay.php
+++ b/examples/CreditCard/ssl-pay.php
@@ -9,7 +9,7 @@ require __DIR__ . '/../../vendor/autoload.php';
 require __DIR__ . '/../inc/common.php';
 
 use Wirecard\PaymentSdk\Config;
-use Wirecard\PaymentSdk\Entity\Money;
+use Wirecard\PaymentSdk\Entity\Amount;
 use Wirecard\PaymentSdk\Response\FailureResponse;
 use Wirecard\PaymentSdk\Response\SuccessResponse;
 use Wirecard\PaymentSdk\Transaction\CreditCardTransaction;
@@ -34,8 +34,8 @@ $ccardConfig = new Config\PaymentMethodConfig(CreditCardTransaction::NAME, $ccar
 $config->add($ccardConfig);
 
 // ### Transaction related objects
-// Create a money object as amount which has to be payed by the consumer.
-$amount = new Money(12.59, 'EUR');
+// Create a amount object as amount which has to be payed by the consumer.
+$amount = new Amount(12.59, 'EUR');
 
 // If there was a previous transaction, use the ID of this parent transaction as reference.
 $parentTransactionId = array_key_exists('parentTransactionId', $_POST) ? $_POST['parentTransactionId'] : null;

--- a/examples/CreditCard/ssl-reserve.php
+++ b/examples/CreditCard/ssl-reserve.php
@@ -9,7 +9,7 @@ require __DIR__ . '/../../vendor/autoload.php';
 require __DIR__ . '/../inc/common.php';
 
 use Wirecard\PaymentSdk\Config;
-use Wirecard\PaymentSdk\Entity\Money;
+use Wirecard\PaymentSdk\Entity\Amount;
 use Wirecard\PaymentSdk\Response\FailureResponse;
 use Wirecard\PaymentSdk\Response\SuccessResponse;
 use Wirecard\PaymentSdk\Transaction\CreditCardTransaction;
@@ -34,8 +34,8 @@ $ccardConfig = new Config\PaymentMethodConfig(CreditCardTransaction::NAME, $ccar
 $config->add($ccardConfig);
 
 // ### Transaction related objects
-// Create a money object as amount which has to be payed by the consumer.
-$amount = new Money(12.59, 'EUR');
+// Create a amount object as amount which has to be payed by the consumer.
+$amount = new Amount(12.59, 'EUR');
 
 // If there was a previous transaction, use the ID of this parent transaction as reference.
 $parentTransactionId = array_key_exists('parentTransactionId', $_POST) ? $_POST['parentTransactionId'] : null;

--- a/examples/PayPal/credit.php
+++ b/examples/PayPal/credit.php
@@ -10,7 +10,7 @@ require __DIR__ . '/../inc/common.php';
 
 use Wirecard\PaymentSdk\Config;
 use Wirecard\PaymentSdk\Entity\AccountHolder;
-use Wirecard\PaymentSdk\Entity\Money;
+use Wirecard\PaymentSdk\Entity\Amount;
 use Wirecard\PaymentSdk\Entity\Redirect;
 use Wirecard\PaymentSdk\Response\FailureResponse;
 use Wirecard\PaymentSdk\Response\SuccessResponse;
@@ -35,8 +35,8 @@ $paypalKey = '5fca2a83-89ca-4f9e-8cf7-4ca74a02773f';
 $paypalConfig = new Config\PaymentMethodConfig(PayPalTransaction::NAME, $paypalMAID, $paypalKey);
 $config->add($paypalConfig);
 
-// Use the money object as amount which has to be payed by the consumer.
-$amount = new Money(12.59, 'EUR');
+// Use the amount object as amount which has to be payed by the consumer.
+$amount = new Amount(12.59, 'EUR');
 
 // ### Redirect URLs
 // The redirect URLs determine where the consumer should be redirected by PayPal after approval/cancellation.

--- a/examples/PayPal/pay-based-on-reserve.php
+++ b/examples/PayPal/pay-based-on-reserve.php
@@ -8,7 +8,7 @@ require __DIR__ . '/../../vendor/autoload.php';
 require __DIR__ . '/../inc/common.php';
 
 use Wirecard\PaymentSdk\Config;
-use Wirecard\PaymentSdk\Entity\Money;
+use Wirecard\PaymentSdk\Entity\Amount;
 use Wirecard\PaymentSdk\Entity\Redirect;
 use Wirecard\PaymentSdk\Response\FailureResponse;
 use Wirecard\PaymentSdk\Response\SuccessResponse;
@@ -36,11 +36,11 @@ $config->add($paypalConfig);
 
 // ### Transaction related objects
 
-// Use the money object as amount which has to be payed by the consumer.
+// Use the amount object as amount which has to be payed by the consumer.
 if (array_key_exists('amount', $_POST)) {
-    $amount = new Money((float)$_POST['amount'], 'EUR');
+    $amount = new Amount((float)$_POST['amount'], 'EUR');
 } else {
-    $amount = new Money(12.59, 'EUR');
+    $amount = new Amount(12.59, 'EUR');
 }
 
 // The redirect URLs determine where the consumer should be redirected by PayPal after approval/cancellation.

--- a/examples/PayPal/pay.php
+++ b/examples/PayPal/pay.php
@@ -8,7 +8,7 @@ require __DIR__ . '/../../vendor/autoload.php';
 require __DIR__ . '/../inc/common.php';
 
 use Wirecard\PaymentSdk\Config;
-use Wirecard\PaymentSdk\Entity\Money;
+use Wirecard\PaymentSdk\Entity\Amount;
 use Wirecard\PaymentSdk\Entity\Redirect;
 use Wirecard\PaymentSdk\Response\FailureResponse;
 use Wirecard\PaymentSdk\Response\InteractionResponse;
@@ -34,8 +34,8 @@ $paypalConfig = new Config\PaymentMethodConfig(PayPalTransaction::NAME, $paypalM
 $config->add($paypalConfig);
 
 // ### Transaction related objects
-// Use the money object as amount which has to be payed by the consumer.
-$amount = new Money(12.59, 'EUR');
+// Use the amount object as amount which has to be payed by the consumer.
+$amount = new Amount(12.59, 'EUR');
 
 // The redirect URLs determine where the consumer should be redirected by PayPal after approval/cancellation.
 $redirectUrls = new Redirect(getUrl('return.php?status=success'), getUrl('return.php?status=cancel'));

--- a/examples/PayPal/reserve.php
+++ b/examples/PayPal/reserve.php
@@ -8,7 +8,7 @@ require __DIR__ . '/../../vendor/autoload.php';
 require __DIR__ . '/../inc/common.php';
 
 use Wirecard\PaymentSdk\Config;
-use Wirecard\PaymentSdk\Entity\Money;
+use Wirecard\PaymentSdk\Entity\Amount;
 use Wirecard\PaymentSdk\Entity\Redirect;
 use Wirecard\PaymentSdk\Response\FailureResponse;
 use Wirecard\PaymentSdk\Response\InteractionResponse;
@@ -34,8 +34,8 @@ $paypalConfig = new Config\PaymentMethodConfig(PayPalTransaction::NAME, $paypalM
 $config->add($paypalConfig);
 
 // ### Transaction related objects
-// Use the money object as amount which has to be payed by the consumer.
-$amount = new Money(12.59, 'EUR');
+// Use the amount object as amount which has to be payed by the consumer.
+$amount = new Amount(12.59, 'EUR');
 
 // If there was a previous transaction, use the ID of this parent transaction as reference.
 $parentTransactionId = array_key_exists('parentTransactionId', $_POST) ? $_POST['parentTransactionId'] : null;
@@ -48,14 +48,14 @@ $notificationUrl = getUrl('notify.php');
 
 // #### Order items
 // Create your items.
-$item1 = new \Wirecard\PaymentSdk\Entity\Item('Item 1', new Money(2.59, 'EUR'), 1);
+$item1 = new \Wirecard\PaymentSdk\Entity\Item('Item 1', new Amount(2.59, 'EUR'), 1);
 $item1->setArticleNumber('A1');
 $item1->setDescription('My first item');
 
-$item2 = new \Wirecard\PaymentSdk\Entity\Item('Item 2', new Money(5, 'EUR'), 2);
+$item2 = new \Wirecard\PaymentSdk\Entity\Item('Item 2', new Amount(5, 'EUR'), 2);
 $item2->setArticleNumber('B2');
 $item2->setDescription('My second item');
-$item2->setTaxAmount(new Money(1, 'EUR'));
+$item2->setTaxAmount(new Amount(1, 'EUR'));
 
 // Create an item collection to store the items.
 $itemCollection = new \Wirecard\PaymentSdk\Entity\ItemCollection();

--- a/examples/RatePAY_Installment/cancel.php
+++ b/examples/RatePAY_Installment/cancel.php
@@ -8,7 +8,7 @@ require __DIR__ . '/../../vendor/autoload.php';
 require __DIR__ . '/../inc/common.php';
 
 use Wirecard\PaymentSdk\Config;
-use Wirecard\PaymentSdk\Entity\Money;
+use Wirecard\PaymentSdk\Entity\Amount;
 use Wirecard\PaymentSdk\Response\FailureResponse;
 use Wirecard\PaymentSdk\Response\SuccessResponse;
 use Wirecard\PaymentSdk\Transaction\RatepayInstallmentTransaction;
@@ -39,13 +39,13 @@ $config->add($ratepayConfig);
 
 
 // ### Transaction related objects
-// Use the money object as amount which has to be payed by the consumer.
+// Use the amount object as amount which has to be payed by the consumer.
 if (array_key_exists('amount', $_POST)) {
     $amountValue = $_POST['amount'];
 } else {
     $amountValue = 2400;
 }
-$amount = new Money($amountValue, 'EUR');
+$amount = new Amount($amountValue, 'EUR');
 
 // The order number
 $orderNumber = 'A2';
@@ -53,11 +53,11 @@ $orderNumber = 'A2';
 
 // #### Order items
 // Create your items.
-$item1 = new \Wirecard\PaymentSdk\Entity\Item('Item 1', new Money(400, 'EUR'), 1);
+$item1 = new \Wirecard\PaymentSdk\Entity\Item('Item 1', new Amount(400, 'EUR'), 1);
 $item1->setArticleNumber('A1');
 $item1->setTaxRate(0.1);
 
-$item2 = new \Wirecard\PaymentSdk\Entity\Item('Item 2', new Money(1000, 'EUR'), 2);
+$item2 = new \Wirecard\PaymentSdk\Entity\Item('Item 2', new Amount(1000, 'EUR'), 2);
 $item2->setArticleNumber('B2');
 $item2->setTaxRate(0.2);
 

--- a/examples/RatePAY_Installment/credit.php
+++ b/examples/RatePAY_Installment/credit.php
@@ -9,7 +9,7 @@ require __DIR__ . '/../../vendor/autoload.php';
 require __DIR__ . '/../inc/common.php';
 
 use Wirecard\PaymentSdk\Config;
-use Wirecard\PaymentSdk\Entity\Money;
+use Wirecard\PaymentSdk\Entity\Amount;
 use Wirecard\PaymentSdk\Entity\Redirect;
 use Wirecard\PaymentSdk\Response\FailureResponse;
 use Wirecard\PaymentSdk\Response\SuccessResponse;
@@ -39,13 +39,13 @@ $ratepayConfig = new Config\PaymentMethodConfig(
 );
 $config->add($ratepayConfig);
 
-// Use the money object as amount which has to be payed by the consumer.
+// Use the amount object as amount which has to be payed by the consumer.
 if (array_key_exists('amount', $_POST)) {
     $amountValue = $_POST['amount'];
 } else {
     $amountValue = 100;
 }
-$amount = new Money($amountValue, 'EUR');
+$amount = new Amount($amountValue, 'EUR');
 
 // ### Redirect URLs
 // The redirect URLs determine where the consumer should be redirected by RatePAY after approval/cancellation.

--- a/examples/RatePAY_Installment/pay-based-on-reserve.php
+++ b/examples/RatePAY_Installment/pay-based-on-reserve.php
@@ -8,7 +8,7 @@ require __DIR__ . '/../../vendor/autoload.php';
 require __DIR__ . '/../inc/common.php';
 
 use Wirecard\PaymentSdk\Config;
-use Wirecard\PaymentSdk\Entity\Money;
+use Wirecard\PaymentSdk\Entity\Amount;
 use Wirecard\PaymentSdk\Entity\Redirect;
 use Wirecard\PaymentSdk\Response\FailureResponse;
 use Wirecard\PaymentSdk\Response\SuccessResponse;
@@ -52,11 +52,11 @@ $orderNumber = 'A2';
 
 // #### Order items
 // Create your items.
-$item1 = new \Wirecard\PaymentSdk\Entity\Item('Item 1', new Money(400, 'EUR'), 1);
+$item1 = new \Wirecard\PaymentSdk\Entity\Item('Item 1', new Amount(400, 'EUR'), 1);
 $item1->setArticleNumber('A1');
 $item1->setTaxRate(0.1);
 
-$item2 = new \Wirecard\PaymentSdk\Entity\Item('Item 2', new Money(1000, 'EUR'), 2);
+$item2 = new \Wirecard\PaymentSdk\Entity\Item('Item 2', new Amount(1000, 'EUR'), 2);
 $item2->setArticleNumber('B2');
 $item2->setTaxRate(0.2);
 
@@ -96,16 +96,16 @@ if (array_key_exists('item_to_capture', $_POST)) {
     switch ($_POST['item_to_capture']) {
         case '1':
             $itemCollection->add($item1);
-            $amount = new Money(400, 'EUR');
+            $amount = new Amount(400, 'EUR');
             break;
         case '2':
             $itemCollection->add($item2);
-            $amount = new Money(2000, 'EUR');
+            $amount = new Amount(2000, 'EUR');
             break;
         default:
             $itemCollection->add($item1);
             $itemCollection->add($item2);
-            $amount = new Money(2400, 'EUR');
+            $amount = new Amount(2400, 'EUR');
     }
     $transaction->setAmount($amount);
 }

--- a/examples/RatePAY_Installment/reserve.php
+++ b/examples/RatePAY_Installment/reserve.php
@@ -8,7 +8,7 @@ require __DIR__ . '/../../vendor/autoload.php';
 require __DIR__ . '/../inc/common.php';
 
 use Wirecard\PaymentSdk\Config;
-use Wirecard\PaymentSdk\Entity\Money;
+use Wirecard\PaymentSdk\Entity\Amount;
 use Wirecard\PaymentSdk\Entity\Redirect;
 use Wirecard\PaymentSdk\Response\FailureResponse;
 use Wirecard\PaymentSdk\Response\InteractionResponse;
@@ -39,8 +39,8 @@ $ratepayConfig = new Config\PaymentMethodConfig(
 $config->add($ratepayConfig);
 
 // ### Transaction related objects
-// Use the money object as amount which has to be payed by the consumer.
-$amount = new Money(2400, 'EUR');
+// Use the amount object as amount which has to be payed by the consumer.
+$amount = new Amount(2400, 'EUR');
 
 // The redirect URLs determine where the consumer should be redirected by RatePAY installment after the reserve.
 $redirectUrls = new Redirect(
@@ -57,11 +57,11 @@ $orderNumber = 'A2';
 
 // #### Order items
 // Create your items.
-$item1 = new \Wirecard\PaymentSdk\Entity\Item('Item 1', new Money(400, 'EUR'), 1);
+$item1 = new \Wirecard\PaymentSdk\Entity\Item('Item 1', new Amount(400, 'EUR'), 1);
 $item1->setArticleNumber('A1');
 $item1->setTaxRate(0.1);
 
-$item2 = new \Wirecard\PaymentSdk\Entity\Item('Item 2', new Money(1000, 'EUR'), 2);
+$item2 = new \Wirecard\PaymentSdk\Entity\Item('Item 2', new Amount(1000, 'EUR'), 2);
 $item2->setArticleNumber('B2');
 $item2->setTaxRate(0.2);
 

--- a/examples/RatePAY_Invoice/cancel.php
+++ b/examples/RatePAY_Invoice/cancel.php
@@ -8,7 +8,7 @@ require __DIR__ . '/../../vendor/autoload.php';
 require __DIR__ . '/../inc/common.php';
 
 use Wirecard\PaymentSdk\Config;
-use Wirecard\PaymentSdk\Entity\Money;
+use Wirecard\PaymentSdk\Entity\Amount;
 use Wirecard\PaymentSdk\Response\FailureResponse;
 use Wirecard\PaymentSdk\Response\SuccessResponse;
 use Wirecard\PaymentSdk\Transaction\RatepayInvoiceTransaction;
@@ -39,13 +39,13 @@ $config->add($ratepayInvoiceConfig);
 
 
 // ### Transaction related objects
-// Use the money object as amount which has to be payed by the consumer.
+// Use the amount object as amount which has to be payed by the consumer.
 if (array_key_exists('amount', $_POST)) {
     $amountValue = $_POST['amount'];
 } else {
     $amountValue = 2400;
 }
-$amount = new Money($amountValue, 'EUR');
+$amount = new Amount($amountValue, 'EUR');
 
 // The order number
 $orderNumber = 'A2';
@@ -53,11 +53,11 @@ $orderNumber = 'A2';
 
 // #### Order items
 // Create your items.
-$item1 = new \Wirecard\PaymentSdk\Entity\Item('Item 1', new Money(400, 'EUR'), 1);
+$item1 = new \Wirecard\PaymentSdk\Entity\Item('Item 1', new Amount(400, 'EUR'), 1);
 $item1->setArticleNumber('A1');
 $item1->setTaxRate(0.1);
 
-$item2 = new \Wirecard\PaymentSdk\Entity\Item('Item 2', new Money(1000, 'EUR'), 2);
+$item2 = new \Wirecard\PaymentSdk\Entity\Item('Item 2', new Amount(1000, 'EUR'), 2);
 $item2->setArticleNumber('B2');
 $item2->setTaxRate(0.2);
 

--- a/examples/RatePAY_Invoice/credit.php
+++ b/examples/RatePAY_Invoice/credit.php
@@ -9,7 +9,7 @@ require __DIR__ . '/../../vendor/autoload.php';
 require __DIR__ . '/../inc/common.php';
 
 use Wirecard\PaymentSdk\Config;
-use Wirecard\PaymentSdk\Entity\Money;
+use Wirecard\PaymentSdk\Entity\Amount;
 use Wirecard\PaymentSdk\Response\FailureResponse;
 use Wirecard\PaymentSdk\Response\SuccessResponse;
 use Wirecard\PaymentSdk\Transaction\RatepayInvoiceTransaction;
@@ -38,13 +38,13 @@ $ratepayConfig = new Config\PaymentMethodConfig(
 );
 $config->add($ratepayConfig);
 
-// Use the money object as amount which has to be payed by the consumer.
+// Use the amount object as amount which has to be payed by the consumer.
 if (array_key_exists('amount', $_POST)) {
     $amountValue = $_POST['amount'];
 } else {
     $amountValue = 100;
 }
-$amount = new Money($amountValue, 'EUR');
+$amount = new Amount($amountValue, 'EUR');
 
 // ### Notification URL
 // As soon as the transaction status changes, a server-to-server notification will get delivered to this URL.

--- a/examples/RatePAY_Invoice/pay-based-on-reserve.php
+++ b/examples/RatePAY_Invoice/pay-based-on-reserve.php
@@ -8,7 +8,7 @@ require __DIR__ . '/../../vendor/autoload.php';
 require __DIR__ . '/../inc/common.php';
 
 use Wirecard\PaymentSdk\Config;
-use Wirecard\PaymentSdk\Entity\Money;
+use Wirecard\PaymentSdk\Entity\Amount;
 use Wirecard\PaymentSdk\Response\FailureResponse;
 use Wirecard\PaymentSdk\Response\SuccessResponse;
 use Wirecard\PaymentSdk\Transaction\RatepayInvoiceTransaction;
@@ -48,11 +48,11 @@ $orderNumber = 'A2';
 
 // #### Order items
 // Create your items.
-$item1 = new \Wirecard\PaymentSdk\Entity\Item('Item 1', new Money(400, 'EUR'), 1);
+$item1 = new \Wirecard\PaymentSdk\Entity\Item('Item 1', new Amount(400, 'EUR'), 1);
 $item1->setArticleNumber('A1');
 $item1->setTaxRate(0.1);
 
-$item2 = new \Wirecard\PaymentSdk\Entity\Item('Item 2', new Money(1000, 'EUR'), 2);
+$item2 = new \Wirecard\PaymentSdk\Entity\Item('Item 2', new Amount(1000, 'EUR'), 2);
 $item2->setArticleNumber('B2');
 $item2->setTaxRate(0.2);
 
@@ -92,16 +92,16 @@ if (array_key_exists('item_to_capture', $_POST)) {
     switch ($_POST['item_to_capture']) {
         case '1':
             $itemCollection->add($item1);
-            $amount = new Money(400, 'EUR');
+            $amount = new Amount(400, 'EUR');
             break;
         case '2':
             $itemCollection->add($item2);
-            $amount = new Money(2000, 'EUR');
+            $amount = new Amount(2000, 'EUR');
             break;
         default:
             $itemCollection->add($item1);
             $itemCollection->add($item2);
-            $amount = new Money(2400, 'EUR');
+            $amount = new Amount(2400, 'EUR');
     }
     $transaction->setAmount($amount);
 }

--- a/examples/RatePAY_Invoice/reserve.php
+++ b/examples/RatePAY_Invoice/reserve.php
@@ -8,7 +8,7 @@ require __DIR__ . '/../../vendor/autoload.php';
 require __DIR__ . '/../inc/common.php';
 
 use Wirecard\PaymentSdk\Config;
-use Wirecard\PaymentSdk\Entity\Money;
+use Wirecard\PaymentSdk\Entity\Amount;
 use Wirecard\PaymentSdk\Response\FailureResponse;
 use Wirecard\PaymentSdk\Response\SuccessResponse;
 use Wirecard\PaymentSdk\Transaction\RatepayInvoiceTransaction;
@@ -38,8 +38,8 @@ $ratepayInvoiceConfig = new Config\PaymentMethodConfig(
 $config->add($ratepayInvoiceConfig);
 
 // ### Transaction related objects
-// Use the money object as amount which has to be payed by the consumer.
-$amount = new Money(2400, 'EUR');
+// Use the amount object as amount which has to be payed by the consumer.
+$amount = new Amount(2400, 'EUR');
 
 // As soon as the transaction status changes, a server-to-server notification will get delivered to this URL.
 $notificationUrl = getUrl('notify.php');
@@ -49,11 +49,11 @@ $orderNumber = 'A2';
 
 // #### Order items
 // Create your items.
-$item1 = new \Wirecard\PaymentSdk\Entity\Item('Item 1', new Money(400, 'EUR'), 1);
+$item1 = new \Wirecard\PaymentSdk\Entity\Item('Item 1', new Amount(400, 'EUR'), 1);
 $item1->setArticleNumber('A1');
 $item1->setTaxRate(0.1);
 
-$item2 = new \Wirecard\PaymentSdk\Entity\Item('Item 2', new Money(1000, 'EUR'), 2);
+$item2 = new \Wirecard\PaymentSdk\Entity\Item('Item 2', new Amount(1000, 'EUR'), 2);
 $item2->setArticleNumber('B2');
 $item2->setTaxRate(0.2);
 

--- a/examples/Sepa/credit.php
+++ b/examples/Sepa/credit.php
@@ -10,7 +10,7 @@ use Wirecard\PaymentSdk\Config;
 use Wirecard\PaymentSdk\Config\PaymentMethodConfig;
 use Wirecard\PaymentSdk\Entity\AccountHolder;
 use Wirecard\PaymentSdk\Entity\Mandate;
-use Wirecard\PaymentSdk\Entity\Money;
+use Wirecard\PaymentSdk\Entity\Amount;
 use Wirecard\PaymentSdk\Response\FailureResponse;
 use Wirecard\PaymentSdk\Response\SuccessResponse;
 use Wirecard\PaymentSdk\Transaction\SepaTransaction;
@@ -36,10 +36,10 @@ $config->add($sepaConfig);
 
 
 // ### Transaction related objects
-// Create a money object as amount which has to be payed by the consumer.
+// Create an amount object as amount which has to be payed by the consumer.
 $amount = null;
 if (empty($_POST['amount']) && empty($_POST['parentTransactionId'])) {
-    $amount = new Money(10, 'EUR');
+    $amount = new Amount(10, 'EUR');
 }
 
 // The account holder (first name, last name) is required.

--- a/examples/Sepa/pay.php
+++ b/examples/Sepa/pay.php
@@ -11,7 +11,7 @@ require __DIR__ . '/../inc/common.php';
 use Wirecard\PaymentSdk\Config;
 use Wirecard\PaymentSdk\Entity\AccountHolder;
 use Wirecard\PaymentSdk\Entity\Mandate;
-use Wirecard\PaymentSdk\Entity\Money;
+use Wirecard\PaymentSdk\Entity\Amount;
 use Wirecard\PaymentSdk\Response\FailureResponse;
 use Wirecard\PaymentSdk\Response\SuccessResponse;
 use Wirecard\PaymentSdk\Transaction\SepaTransaction;
@@ -40,14 +40,14 @@ $config->add($sepaConfig);
 
 // ### Transaction related objects
 
-// Create a money object as amount which has to be payed by the consumer.
+// Create an amount object as amount which has to be payed by the consumer.
 $amount = null;
 if (!empty($_POST['amount'])) {
-    $amount = new Money((float)$_POST['amount'], 'EUR');
+    $amount = new Amount((float)$_POST['amount'], 'EUR');
 }
 
 if (empty($_POST['amount']) && empty($_POST['parentTransactionId'])) {
-    $amount = new Money(12.59, 'EUR');
+    $amount = new Amount(12.59, 'EUR');
 }
 
 // The account holder (first name, last name) is required.

--- a/examples/Sepa/reserve.php
+++ b/examples/Sepa/reserve.php
@@ -11,7 +11,7 @@ require __DIR__ . '/../inc/common.php';
 use Wirecard\PaymentSdk\Config;
 use Wirecard\PaymentSdk\Config\SepaConfig;
 use Wirecard\PaymentSdk\Entity\AccountHolder;
-use Wirecard\PaymentSdk\Entity\Money;
+use Wirecard\PaymentSdk\Entity\Amount;
 use Wirecard\PaymentSdk\Response\FailureResponse;
 use Wirecard\PaymentSdk\Response\SuccessResponse;
 use Wirecard\PaymentSdk\Transaction\SepaTransaction;
@@ -38,8 +38,8 @@ $config->add($sepaConfig);
 
 // ### Transaction related objects
 
-// Create a money object as amount which has to be payed by the consumer.
-$amount = new Money(7, 'EUR');
+// Create an amount object as amount which has to be payed by the consumer.
+$amount = new Amount(7, 'EUR');
 
 $accountHolder = new AccountHolder();
 $accountHolder->setLastName('Doe');

--- a/examples/Sofort/pay.php
+++ b/examples/Sofort/pay.php
@@ -9,7 +9,7 @@ require __DIR__ . '/../inc/common.php';
 
 use Wirecard\PaymentSdk\Config;
 use Wirecard\PaymentSdk\Config\PaymentMethodConfig;
-use Wirecard\PaymentSdk\Entity\Money;
+use Wirecard\PaymentSdk\Entity\Amount;
 use Wirecard\PaymentSdk\Entity\Redirect;
 use Wirecard\PaymentSdk\Response\FailureResponse;
 use Wirecard\PaymentSdk\Response\InteractionResponse;
@@ -36,8 +36,8 @@ $config->add($sofortConfig);
 
 // ### Transaction related objects
 
-// Use the money object as amount which has to be payed by the consumer.
-$amount = new Money(12.59, 'EUR');
+// Use the amount object as amount which has to be payed by the consumer.
+$amount = new Amount(12.59, 'EUR');
 
 // The redirect URLs determine where the consumer should be redirected by Sofortbanking after approval/cancellation.
 $redirectUrls = new Redirect(getUrl('return.php?status=success'), getUrl('return.php?status=cancel'));

--- a/examples/iDEAL/pay.php
+++ b/examples/iDEAL/pay.php
@@ -11,7 +11,7 @@ use Wirecard\PaymentSdk\Config;
 use Wirecard\PaymentSdk\Config\PaymentMethodConfig;
 use Wirecard\PaymentSdk\Entity\AccountHolder;
 use Wirecard\PaymentSdk\Entity\IdealBic;
-use Wirecard\PaymentSdk\Entity\Money;
+use Wirecard\PaymentSdk\Entity\Amount;
 use Wirecard\PaymentSdk\Entity\Redirect;
 use Wirecard\PaymentSdk\Response\FailureResponse;
 use Wirecard\PaymentSdk\Response\InteractionResponse;
@@ -39,8 +39,8 @@ $config->add($IdealConfig);
 
 // ### Transaction related objects
 
-// Use the money object as amount which has to be payed by the consumer.
-$amount = new Money(12.59, 'EUR');
+// Use the amount object as amount which has to be payed by the consumer.
+$amount = new Amount(12.59, 'EUR');
 
 // The redirect URLs determine where the consumer should be redirected by iDEAL after approval/cancellation.
 $redirectUrls = new Redirect(getUrl('return.php?status=success'), getUrl('return.php?status=cancel'));

--- a/examples/paysafecard/pay-based-on-reserve.php
+++ b/examples/paysafecard/pay-based-on-reserve.php
@@ -8,7 +8,7 @@ require __DIR__ . '/../../vendor/autoload.php';
 require __DIR__ . '/../inc/common.php';
 
 use Wirecard\PaymentSdk\Config;
-use Wirecard\PaymentSdk\Entity\Money;
+use Wirecard\PaymentSdk\Entity\Amount;
 use Wirecard\PaymentSdk\Response\FailureResponse;
 use Wirecard\PaymentSdk\Response\SuccessResponse;
 use Wirecard\PaymentSdk\Transaction\PaysafecardTransaction;
@@ -35,11 +35,11 @@ $config->add($paysafecardConfig);
 
 // ### Transaction related objects
 
-// Use the money object as amount which has to be payed by the consumer.
+// Use the amount object as amount which has to be payed by the consumer.
 if (array_key_exists('amount', $_POST)) {
-    $amount = new Money((float)$_POST['amount'], 'EUR');
+    $amount = new Amount((float)$_POST['amount'], 'EUR');
 } else {
-    $amount = new Money(12.59, 'EUR');
+    $amount = new Amount(12.59, 'EUR');
 }
 
 // ## Transaction

--- a/examples/paysafecard/pay.php
+++ b/examples/paysafecard/pay.php
@@ -9,7 +9,7 @@ require __DIR__ . '/../inc/common.php';
 
 use Wirecard\PaymentSdk\Config;
 use Wirecard\PaymentSdk\Entity\AccountHolder;
-use Wirecard\PaymentSdk\Entity\Money;
+use Wirecard\PaymentSdk\Entity\Amount;
 use Wirecard\PaymentSdk\Entity\Redirect;
 use Wirecard\PaymentSdk\Response\FailureResponse;
 use Wirecard\PaymentSdk\Response\InteractionResponse;
@@ -35,8 +35,8 @@ $paysafecardConfig = new Config\PaymentMethodConfig(PaysafecardTransaction::NAME
 $config->add($paysafecardConfig);
 
 // ### Transaction related objects
-// Use the money object as amount which has to be payed by the consumer.
-$amount = new Money(12.59, 'EUR');
+// Use the amount object as amount which has to be payed by the consumer.
+$amount = new Amount(12.59, 'EUR');
 
 // The redirect URLs determine where the consumer should be redirected by Paysafecard after approval/cancellation.
 $redirectUrls = new Redirect(getUrl('return.php?status=success'), getUrl('return.php?status=cancel'));

--- a/examples/paysafecard/reserve.php
+++ b/examples/paysafecard/reserve.php
@@ -9,7 +9,7 @@ require __DIR__ . '/../inc/common.php';
 
 use Wirecard\PaymentSdk\Config;
 use Wirecard\PaymentSdk\Entity\AccountHolder;
-use Wirecard\PaymentSdk\Entity\Money;
+use Wirecard\PaymentSdk\Entity\Amount;
 use Wirecard\PaymentSdk\Entity\Redirect;
 use Wirecard\PaymentSdk\Response\FailureResponse;
 use Wirecard\PaymentSdk\Response\InteractionResponse;
@@ -35,8 +35,8 @@ $paysafecardConfig = new Config\PaymentMethodConfig(PaysafecardTransaction::NAME
 $config->add($paysafecardConfig);
 
 // ### Transaction related objects
-// Use the money object as amount which has to be payed by the consumer.
-$amount = new Money(12.59, 'EUR');
+// Use the amount object as amount which has to be payed by the consumer.
+$amount = new Amount(12.59, 'EUR');
 
 // If there was a previous transaction, use the ID of this parent transaction as reference.
 $parentTransactionId = array_key_exists('parentTransactionId', $_POST) ? $_POST['parentTransactionId'] : null;

--- a/src/Entity/AccountHolder.php
+++ b/src/Entity/AccountHolder.php
@@ -33,7 +33,7 @@
 namespace Wirecard\PaymentSdk\Entity;
 
 /**
- * Class Money
+ * Class AccountHolder
  * @package Wirecard\PaymentSdk\Entity
  *
  * An immutable entity representing an account holder.

--- a/src/Entity/Amount.php
+++ b/src/Entity/Amount.php
@@ -33,17 +33,17 @@
 namespace Wirecard\PaymentSdk\Entity;
 
 /**
- * Class Money
+ * Class Amount
  * @package Wirecard\PaymentSdk\Entity
  *
- * An immutable entity representing a money: amount and currency.
+ * An immutable entity representing an amount: value and currency.
  */
-class Money implements MappableEntity
+class Amount implements MappableEntity
 {
     /**
      * @var float
      */
-    private $amount;
+    private $value;
 
     /**
      * @var string
@@ -51,22 +51,22 @@ class Money implements MappableEntity
     private $currency;
 
     /**
-     * Money constructor.
-     * @param float $amount
+     * Amount constructor.
+     * @param float $value
      * @param string $currency
      */
-    public function __construct($amount, $currency)
+    public function __construct($value, $currency)
     {
-        $this->amount = $amount;
+        $this->value = $value;
         $this->currency = $currency;
     }
 
     /**
      * @return float
      */
-    public function getAmount()
+    public function getValue()
     {
-        return $this->amount;
+        return $this->value;
     }
 
     /**
@@ -84,7 +84,7 @@ class Money implements MappableEntity
     {
         return [
             'currency' => $this->currency,
-            'value' => $this->amount
+            'value' => $this->value
         ];
     }
 }

--- a/src/Entity/Item.php
+++ b/src/Entity/Item.php
@@ -53,12 +53,12 @@ class Item implements MappableEntity
     private $articleNumber;
 
     /**
-     * @var Money
+     * @var Amount
      */
     private $amount;
 
     /**
-     * @var Money
+     * @var Amount
      */
     private $taxAmount;
 
@@ -75,10 +75,10 @@ class Item implements MappableEntity
     /**
      * Item constructor.
      * @param string $name
-     * @param Money $amount
+     * @param Amount $amount
      * @param int $quantity
      */
-    public function __construct($name, Money $amount, $quantity)
+    public function __construct($name, Amount $amount, $quantity)
     {
         $this->name = $name;
         $this->amount = $amount;
@@ -124,7 +124,7 @@ class Item implements MappableEntity
     }
 
     /**
-     * @param Money $taxAmount
+     * @param Amount $taxAmount
      * @return Item
      */
     public function setTaxAmount($taxAmount)
@@ -158,7 +158,7 @@ class Item implements MappableEntity
     }
 
     /**
-     * @return Money
+     * @return Amount
      */
     public function getAmount()
     {
@@ -166,7 +166,7 @@ class Item implements MappableEntity
     }
 
     /**
-     * @return Money
+     * @return Amount
      */
     public function getTaxAmount()
     {

--- a/src/Transaction/PayPalTransaction.php
+++ b/src/Transaction/PayPalTransaction.php
@@ -77,7 +77,7 @@ class PayPalTransaction extends Transaction implements Reservable
      */
     protected function retrieveTransactionTypeForReserve()
     {
-        if ($this->amount->getAmount() === 0.0) {
+        if ($this->amount->getValue() === 0.0) {
             return self::TYPE_AUTHORIZATION_ONLY;
         }
 

--- a/src/Transaction/Transaction.php
+++ b/src/Transaction/Transaction.php
@@ -34,7 +34,7 @@ namespace Wirecard\PaymentSdk\Transaction;
 
 use Wirecard\PaymentSdk\Entity\AccountHolder;
 use Wirecard\PaymentSdk\Entity\ItemCollection;
-use Wirecard\PaymentSdk\Entity\Money;
+use Wirecard\PaymentSdk\Entity\Amount;
 use Wirecard\PaymentSdk\Entity\Redirect;
 use Wirecard\PaymentSdk\Exception\MandatoryFieldMissingException;
 use Wirecard\PaymentSdk\Exception\UnsupportedOperationException;
@@ -70,7 +70,7 @@ abstract class Transaction
     protected $accountHolder;
 
     /**
-     * @var Money
+     * @var Amount
      */
     protected $amount;
 
@@ -123,7 +123,7 @@ abstract class Transaction
     }
 
     /**
-     * @param Money $amount
+     * @param Amount $amount
      */
     public function setAmount($amount)
     {
@@ -211,7 +211,7 @@ abstract class Transaction
             'name' => $this->paymentMethodNameForRequest()
         ]]]];
 
-        if ($this->amount instanceof Money) {
+        if ($this->amount instanceof Amount) {
             $result['requested-amount'] = $this->amount->mappedProperties();
         }
 

--- a/test/Entity/AmountUTest.php
+++ b/test/Entity/AmountUTest.php
@@ -32,30 +32,30 @@
 
 namespace WirecardTest\PaymentSdk\Entity;
 
-use Wirecard\PaymentSdk\Entity\Money;
+use Wirecard\PaymentSdk\Entity\Amount;
 
-class MoneyUTest extends \PHPUnit_Framework_TestCase
+class AmountUTest extends \PHPUnit_Framework_TestCase
 {
-    const AMOUNT = 42.21;
+    const VALUE = 42.21;
     const EUR = 'EUR';
 
     /**
-     * @var Money
+     * @var Amount
      */
-    private $money;
+    private $amount;
 
     public function setUp()
     {
-        $this->money = new Money(self::AMOUNT, self::EUR);
+        $this->amount = new Amount(self::VALUE, self::EUR);
     }
 
-    public function testGetAmount()
+    public function testGetValue()
     {
-        $this->assertEquals(self::AMOUNT, $this->money->getAmount());
+        $this->assertEquals(self::VALUE, $this->amount->getValue());
     }
 
     public function testGetCurrency()
     {
-        $this->assertEquals(self::EUR, $this->money->getCurrency());
+        $this->assertEquals(self::EUR, $this->amount->getCurrency());
     }
 }

--- a/test/Entity/ItemCollectionUTest.php
+++ b/test/Entity/ItemCollectionUTest.php
@@ -64,7 +64,7 @@ namespace WirecardTest\PaymentSdk\Entity;
 
 use Wirecard\PaymentSdk\Entity\Item;
 use Wirecard\PaymentSdk\Entity\ItemCollection;
-use Wirecard\PaymentSdk\Entity\Money;
+use Wirecard\PaymentSdk\Entity\Amount;
 
 class ItemCollectionUTest extends \PHPUnit_Framework_TestCase
 {
@@ -80,7 +80,7 @@ class ItemCollectionUTest extends \PHPUnit_Framework_TestCase
 
     public function testAdd()
     {
-        $item = new Item('test', new Money(1, 'EUR'), 1);
+        $item = new Item('test', new Amount(1, 'EUR'), 1);
         $this->itemCollection->add($item);
 
         $this->assertAttributeEquals([$item], 'items', $this->itemCollection);
@@ -93,7 +93,7 @@ class ItemCollectionUTest extends \PHPUnit_Framework_TestCase
 
     public function testMappedProperties()
     {
-        $item = new Item('test', new Money(1, 'EUR'), 1);
+        $item = new Item('test', new Amount(1, 'EUR'), 1);
         $this->itemCollection->add($item);
 
         $expected = [
@@ -101,7 +101,7 @@ class ItemCollectionUTest extends \PHPUnit_Framework_TestCase
                 [
                     'name' => $item->getName(),
                     'amount' => [
-                        'value' => $item->getAmount()->getAmount(),
+                        'value' => $item->getAmount()->getValue(),
                         'currency' => $item->getAmount()->getCurrency()
                     ],
                     'quantity' => $item->getQuantity()

--- a/test/Entity/ItemUTest.php
+++ b/test/Entity/ItemUTest.php
@@ -63,7 +63,7 @@
 namespace WirecardTest\PaymentSdk\Entity;
 
 use Wirecard\PaymentSdk\Entity\Item;
-use Wirecard\PaymentSdk\Entity\Money;
+use Wirecard\PaymentSdk\Entity\Amount;
 
 class ItemUTest extends \PHPUnit_Framework_TestCase
 {
@@ -71,7 +71,7 @@ class ItemUTest extends \PHPUnit_Framework_TestCase
     const QUANTITY = 1;
 
     /**
-     * @var Money
+     * @var Amount
      */
     private $amount;
 
@@ -82,7 +82,7 @@ class ItemUTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->amount = new Money(1, 'EUR');
+        $this->amount = new Amount(1, 'EUR');
         $this->item = new Item(self::NAME, $this->amount, self::QUANTITY);
     }
 
@@ -167,11 +167,11 @@ class ItemUTest extends \PHPUnit_Framework_TestCase
             'description' => $this->item->getDescription(),
             'article-number' => $this->item->getArticleNumber(),
             'amount' => [
-                'value' => $this->item->getAmount()->getAmount(),
+                'value' => $this->item->getAmount()->getValue(),
                 'currency' => $this->item->getAmount()->getCurrency()
             ],
             'tax-amount' => [
-                'value' => $this->item->getTaxAmount()->getAmount(),
+                'value' => $this->item->getTaxAmount()->getValue(),
                 'currency' => $this->item->getTaxAmount()->getCurrency()
             ],
             'quantity' => $this->item->getQuantity(),

--- a/test/Transaction/CreditCardTransactionUTest.php
+++ b/test/Transaction/CreditCardTransactionUTest.php
@@ -32,7 +32,7 @@
 
 namespace WirecardTest\PaymentSdk\Transaction;
 
-use Wirecard\PaymentSdk\Entity\Money;
+use Wirecard\PaymentSdk\Entity\Amount;
 use Wirecard\PaymentSdk\Transaction\CreditCardTransaction;
 use Wirecard\PaymentSdk\Transaction\Operation;
 use Wirecard\PaymentSdk\Transaction\Transaction;
@@ -85,7 +85,7 @@ class CreditCardTransactionUTest extends \PHPUnit_Framework_TestCase
 
         $transaction = new CreditCardTransaction();
         $transaction->setTokenId('21');
-        $transaction->setAmount(new Money(24, 'EUR'));
+        $transaction->setAmount(new Amount(24, 'EUR'));
         $transaction->setOperation(Operation::RESERVE);
 
         $result = $transaction->mappedProperties();
@@ -104,7 +104,7 @@ class CreditCardTransactionUTest extends \PHPUnit_Framework_TestCase
         ];
 
         $transaction = new CreditCardTransaction();
-        $transaction->setAmount(new Money(24, 'EUR'));
+        $transaction->setAmount(new Amount(24, 'EUR'));
         $transaction->setParentTransactionId('parent5');
         $transaction->setParentTransactionType(Transaction::TYPE_AUTHORIZATION);
         $transaction->setOperation(Operation::RESERVE);
@@ -119,7 +119,7 @@ class CreditCardTransactionUTest extends \PHPUnit_Framework_TestCase
     public function testSslCreditCardTransactionWithoutTokenIdAndParentTransactionId()
     {
         $transaction = new CreditCardTransaction();
-        $transaction->setAmount(new Money(24, 'EUR'));
+        $transaction->setAmount(new Amount(24, 'EUR'));
         $transaction->setOperation(Operation::RESERVE);
         $transaction->mappedProperties();
     }
@@ -141,7 +141,7 @@ class CreditCardTransactionUTest extends \PHPUnit_Framework_TestCase
 
         $transaction = new CreditCardTransaction();
         $transaction->setTokenId('33');
-        $transaction->setAmount(new Money(24, 'EUR'));
+        $transaction->setAmount(new Amount(24, 'EUR'));
         $transaction->setParentTransactionId('parent5');
         $transaction->setParentTransactionType(Transaction::TYPE_AUTHORIZATION);
         $transaction->setOperation(Operation::RESERVE);

--- a/test/Transaction/IdealTransactionUTest.php
+++ b/test/Transaction/IdealTransactionUTest.php
@@ -32,7 +32,7 @@
 
 namespace WirecardTest\PaymentSdk\Transaction;
 
-use Wirecard\PaymentSdk\Entity\Money;
+use Wirecard\PaymentSdk\Entity\Amount;
 use Wirecard\PaymentSdk\Entity\Redirect;
 use Wirecard\PaymentSdk\Transaction\IdealTransaction;
 use Wirecard\PaymentSdk\Transaction\Operation;
@@ -56,7 +56,7 @@ class IdealTransactionUTest extends \PHPUnit_Framework_TestCase
         $this->tx = new IdealTransaction();
         $this->tx->setRedirect($redirect);
         $this->tx->setBic(self::BANK);
-        $this->tx->setAmount(new Money(33, 'USD'));
+        $this->tx->setAmount(new Amount(33, 'USD'));
         $this->tx->setDescriptor(self::DESCRIPTOR);
     }
 

--- a/test/Transaction/PayPalTransactionUTest.php
+++ b/test/Transaction/PayPalTransactionUTest.php
@@ -33,7 +33,7 @@
 namespace WirecardTest\PaymentSdk\Transaction;
 
 use Wirecard\PaymentSdk\Entity\ItemCollection;
-use Wirecard\PaymentSdk\Entity\Money;
+use Wirecard\PaymentSdk\Entity\Amount;
 use Wirecard\PaymentSdk\Entity\Redirect;
 use Wirecard\PaymentSdk\Transaction\Operation;
 use Wirecard\PaymentSdk\Transaction\PayPalTransaction;
@@ -100,21 +100,21 @@ class PayPalTransactionUTest extends \PHPUnit_Framework_TestCase
      * @param string $expected
      * @dataProvider reserveDataProvider
      */
-    public function testGetRetrieveTransactionTypeReserve($amount, $expected)
+    public function testGetRetrieveTransactionTypeReserve($value, $expected)
     {
         $redirect = $this->createMock(Redirect::class);
         $redirect->method('getCancelUrl')->willReturn('cancel-url');
         $redirect->method('getSuccessUrl')->willReturn('success-url');
 
-        $money = $this->createMock(Money::class);
-        $money->method('getAmount')->willReturn($amount);
+        $amount = $this->createMock(Amount::class);
+        $amount->method('getValue')->willReturn($value);
 
         /**
          * @var Redirect $redirect
-         * @var Money $money
+         * @var Amount $amount
          */
         $this->tx->setRedirect($redirect);
-        $this->tx->setAmount($money);
+        $this->tx->setAmount($amount);
         $this->tx->setOperation(Operation::RESERVE);
         $data = $this->tx->mappedProperties();
 
@@ -140,15 +140,15 @@ class PayPalTransactionUTest extends \PHPUnit_Framework_TestCase
         $redirect->method('getCancelUrl')->willReturn('cancel-url');
         $redirect->method('getSuccessUrl')->willReturn('success-url');
 
-        $money = $this->createMock(Money::class);
-        $money->method('getAmount')->willReturn(1.00);
+        $amount = $this->createMock(Amount::class);
+        $amount->method('getValue')->willReturn(1.00);
 
         /**
          * @var Redirect $redirect
-         * @var Money $money
+         * @var Amount $amount
          */
         $this->tx->setRedirect($redirect);
-        $this->tx->setAmount($money);
+        $this->tx->setAmount($amount);
         $this->tx->setParentTransactionType($parentTransactionType);
         $this->tx->setOperation('pay');
         $data = $this->tx->mappedProperties();
@@ -158,20 +158,19 @@ class PayPalTransactionUTest extends \PHPUnit_Framework_TestCase
 
     public function testGetRetrieveTransactionTypeCredit()
     {
-        $amount = 1.00;
         $redirect = $this->createMock(Redirect::class);
         $redirect->method('getCancelUrl')->willReturn('cancel-url');
         $redirect->method('getSuccessUrl')->willReturn('success-url');
 
-        $money = $this->createMock(Money::class);
-        $money->method('getAmount')->willReturn($amount);
+        $amount = $this->createMock(Amount::class);
+        $amount->method('getValue')->willReturn(1.00);
 
         /**
          * @var Redirect $redirect
-         * @var Money $money
+         * @var Amount $amount
          */
         $this->tx->setRedirect($redirect);
-        $this->tx->setAmount($money);
+        $this->tx->setAmount($amount);
 
         $this->tx->setOperation('credit');
 

--- a/test/Transaction/PaysafecardTransactionUTest.php
+++ b/test/Transaction/PaysafecardTransactionUTest.php
@@ -32,7 +32,7 @@
 
 namespace WirecardTest\PaymentSdk\Transaction;
 
-use Wirecard\PaymentSdk\Entity\Money;
+use Wirecard\PaymentSdk\Entity\Amount;
 use Wirecard\PaymentSdk\Entity\Redirect;
 use Wirecard\PaymentSdk\Transaction\Operation;
 use Wirecard\PaymentSdk\Transaction\PaysafecardTransaction;
@@ -53,7 +53,7 @@ class PaysafecardTransactionUTest extends \PHPUnit_Framework_TestCase
         $redirect = new Redirect(self::SUCCESS_URL, self::CANCEL_URL);
         $this->tx = new PaysafecardTransaction();
         $this->tx->setRedirect($redirect);
-        $this->tx->setAmount(new Money(33, 'USD'));
+        $this->tx->setAmount(new Amount(33, 'USD'));
     }
 
     public function testMappedProperties()

--- a/test/Transaction/RatepayTransactionUTest.php
+++ b/test/Transaction/RatepayTransactionUTest.php
@@ -33,7 +33,7 @@
 namespace WirecardTest\PaymentSdk\Transaction;
 
 use Wirecard\PaymentSdk\Entity\ItemCollection;
-use Wirecard\PaymentSdk\Entity\Money;
+use Wirecard\PaymentSdk\Entity\Amount;
 use Wirecard\PaymentSdk\Entity\Redirect;
 use Wirecard\PaymentSdk\Transaction\Operation;
 use Wirecard\PaymentSdk\Transaction\RatepayTransaction;
@@ -114,15 +114,15 @@ class RatepayTransactionUTest extends \PHPUnit_Framework_TestCase
         $redirect->method('getCancelUrl')->willReturn('cancel-url');
         $redirect->method('getSuccessUrl')->willReturn('success-url');
 
-        $money = $this->createMock(Money::class);
-        $money->method('getAmount')->willReturn(1.0);
+        $amount = $this->createMock(Amount::class);
+        $amount->method('getValue')->willReturn(1.0);
 
         /**
          * @var Redirect $redirect
-         * @var Money $money
+         * @var Amount $amount
          */
         $this->tx->setRedirect($redirect);
-        $this->tx->setAmount($money);
+        $this->tx->setAmount($amount);
         $this->tx->setOperation(Operation::RESERVE);
         $data = $this->tx->mappedProperties();
 

--- a/test/Transaction/SepaTransactionUTest.php
+++ b/test/Transaction/SepaTransactionUTest.php
@@ -34,7 +34,7 @@ namespace WirecardTest\PaymentSdk\Transaction;
 
 use Wirecard\PaymentSdk\Entity\AccountHolder;
 use Wirecard\PaymentSdk\Entity\Mandate;
-use Wirecard\PaymentSdk\Entity\Money;
+use Wirecard\PaymentSdk\Entity\Amount;
 use Wirecard\PaymentSdk\Transaction\Operation;
 use Wirecard\PaymentSdk\Transaction\SepaTransaction;
 use Wirecard\PaymentSdk\Transaction\Transaction;
@@ -52,7 +52,7 @@ class SepaTransactionUTest extends \PHPUnit_Framework_TestCase
     private $tx;
 
     /**
-     * @var Money
+     * @var Amount
      */
     private $amount;
 
@@ -63,7 +63,7 @@ class SepaTransactionUTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->amount = new Money(55.5, 'EUR');
+        $this->amount = new Amount(55.5, 'EUR');
         $this->accountHolder = new AccountHolder();
         $this->accountHolder->setLastName(self::LAST_NAME);
         $this->accountHolder->setFirstName(self::FIRST_NAME);

--- a/test/Transaction/SofortTransactionUTest.php
+++ b/test/Transaction/SofortTransactionUTest.php
@@ -32,7 +32,7 @@
 
 namespace WirecardTest\PaymentSdk\Transaction;
 
-use Wirecard\PaymentSdk\Entity\Money;
+use Wirecard\PaymentSdk\Entity\Amount;
 use Wirecard\PaymentSdk\Entity\Redirect;
 use Wirecard\PaymentSdk\Transaction\Operation;
 use Wirecard\PaymentSdk\Transaction\SofortTransaction;
@@ -55,7 +55,7 @@ class SofortTransactionUTest extends \PHPUnit_Framework_TestCase
         $this->tx = new SofortTransaction();
         $this->tx->setRedirect($redirect);
         $this->tx->setDescriptor(self::DESCRIPTOR);
-        $this->tx->setAmount(new Money(33, 'USD'));
+        $this->tx->setAmount(new Amount(33, 'USD'));
     }
 
     /**

--- a/test/Transaction/ThreeDCreditCardTransactionUTest.php
+++ b/test/Transaction/ThreeDCreditCardTransactionUTest.php
@@ -31,7 +31,7 @@
 
 namespace WirecardTest\PaymentSdk\Transaction;
 
-use Wirecard\PaymentSdk\Entity\Money;
+use Wirecard\PaymentSdk\Entity\Amount;
 use Wirecard\PaymentSdk\Transaction\Operation;
 use Wirecard\PaymentSdk\Transaction\ThreeDCreditCardTransaction;
 use Wirecard\PaymentSdk\Transaction\Transaction;
@@ -159,11 +159,11 @@ class ThreeDCreditCardTransactionUTest extends \PHPUnit_Framework_TestCase
             ]
         ];
 
-        $money = new Money(24, 'EUR');
+        $amount = new Amount(24, 'EUR');
         $transaction = new ThreeDCreditCardTransaction();
         $transaction->setTokenId('21');
         $transaction->setTermUrl('https://example.com/r');
-        $transaction->setAmount($money);
+        $transaction->setAmount($amount);
         $transaction->setParentTransactionId('parent54');
         $transaction->setParentTransactionType($parentTransactionType);
         $transaction->setOperation($operation);
@@ -225,11 +225,11 @@ class ThreeDCreditCardTransactionUTest extends \PHPUnit_Framework_TestCase
     {
         $_SERVER['REMOTE_ADDR'] = 'test IP';
 
-        $money = new Money(24, 'EUR');
+        $amount = new Amount(24, 'EUR');
         $transaction = new ThreeDCreditCardTransaction();
         $transaction->setTokenId('21');
         $transaction->setTermUrl('https://example.com/r');
-        $transaction->setAmount($money);
+        $transaction->setAmount($amount);
         $transaction->setParentTransactionId('parent54');
         $transaction->setOperation('test');
         $transaction->mappedProperties();

--- a/test/TransactionServiceUTest.php
+++ b/test/TransactionServiceUTest.php
@@ -39,7 +39,7 @@ use GuzzleHttp\Psr7\Response;
 use Monolog\Logger;
 use Wirecard\PaymentSdk\Config\Config;
 use Wirecard\PaymentSdk\Config\PaymentMethodConfig;
-use Wirecard\PaymentSdk\Entity\Money;
+use Wirecard\PaymentSdk\Entity\Amount;
 use Wirecard\PaymentSdk\Entity\Redirect;
 use Wirecard\PaymentSdk\Exception\MalformedResponseException;
 use Wirecard\PaymentSdk\Response\InteractionResponse;
@@ -217,7 +217,7 @@ class TransactionServiceUTest extends \PHPUnit_Framework_TestCase
         $payPalTransaction = new PayPalTransaction();
         $payPalTransaction->setNotificationUrl('notUrl');
         $payPalTransaction->setRedirect($redirect);
-        $payPalTransaction->setAmount(new Money(20.23, 'EUR'));
+        $payPalTransaction->setAmount(new Amount(20.23, 'EUR'));
 
         return $payPalTransaction;
     }


### PR DESCRIPTION
To stop confusing people, we changed money class to amount class. So that you set an amount object at setAmount and not a money object