### PR TITLE
interaction response for synchronous payment methods

### DIFF
--- a/src/Mapper/ResponseMapper.php
+++ b/src/Mapper/ResponseMapper.php
@@ -137,13 +137,13 @@ class ResponseMapper
      */
     private function getSuccessRedirectUrl()
     {
-        if (null !== $this->transaction->getSuccessUrl()) {
-            return $this->transaction->getSuccessUrl();
-        }
-
         $paymentMethod = $this->getPaymentMethod();
         if (isset($paymentMethod['url'])) {
             return (string)$paymentMethod['url'];
+        }
+
+        if (null !== $this->transaction && null !== $this->transaction->getSuccessUrl()) {
+            return $this->transaction->getSuccessUrl();
         }
 
         return null;

--- a/src/Mapper/ResponseMapper.php
+++ b/src/Mapper/ResponseMapper.php
@@ -149,12 +149,11 @@ class ResponseMapper
     }
 
     /**
-     * @param $payload
-     * @throws MalformedResponseException
      * @return FormInteractionResponse
+     * @throws \Wirecard\PaymentSdk\Exception\MalformedResponseException
      * @throws \InvalidArgumentException
      */
-    private function mapThreeDResponse($payload)
+    private function mapThreeDResponse()
     {
         if (!($this->transaction instanceof ThreeDCreditCardTransaction)) {
             throw new \InvalidArgumentException('Trying to create a 3D response from a non-3D transaction.');
@@ -171,7 +170,7 @@ class ResponseMapper
 
         $redirectUrl = (string)$threeD->{'acs-url'};
 
-        $response = new FormInteractionResponse($payload, $redirectUrl);
+        $response = new FormInteractionResponse($this->simpleXml, $redirectUrl);
 
         $fields = new FormFieldMap();
         $fields->add('TermUrl', $this->transaction->getTermUrl());
@@ -202,7 +201,7 @@ class ResponseMapper
     private function mapSuccessResponse()
     {
         if ((string)$this->simpleXml->{'transaction-type'} === ThreeDCreditCardTransaction::TYPE_CHECK_ENROLLMENT) {
-            return $this->mapThreeDResponse($this->simpleXml);
+            return $this->mapThreeDResponse();
         }
 
         $redirectUrl = $this->getSuccessRedirectUrl();

--- a/src/Mapper/ResponseMapper.php
+++ b/src/Mapper/ResponseMapper.php
@@ -134,8 +134,12 @@ class ResponseMapper
      * @return string|null
      * @throws \Wirecard\PaymentSdk\Exception\MalformedResponseException
      */
-    private function getRedirectUrl()
+    private function getSuccessRedirectUrl()
     {
+        if (null !== $this->transaction->getSuccessUrl()) {
+            return $this->transaction->getSuccessUrl();
+        }
+
         $paymentMethod = $this->getPaymentMethod();
         if (isset($paymentMethod['url'])) {
             return (string)$paymentMethod['url'];
@@ -192,6 +196,7 @@ class ResponseMapper
 
     /**
      * @return FormInteractionResponse|InteractionResponse|SuccessResponse
+     * @throws \InvalidArgumentException
      * @throws MalformedResponseException
      */
     private function mapSuccessResponse()
@@ -200,7 +205,7 @@ class ResponseMapper
             return $this->mapThreeDResponse($this->simpleXml);
         }
 
-        $redirectUrl = $this->getRedirectUrl();
+        $redirectUrl = $this->getSuccessRedirectUrl();
         if ($redirectUrl !== null) {
             return new InteractionResponse($this->simpleXml, $redirectUrl);
         }

--- a/src/Mapper/ResponseMapper.php
+++ b/src/Mapper/ResponseMapper.php
@@ -68,6 +68,7 @@ class ResponseMapper
      * @param string $xmlResponse
      * @param Transaction $transaction
      * @return Response
+     * @throws \InvalidArgumentException
      * @throws MalformedResponseException
      */
     public function map($xmlResponse, Transaction $transaction = null)

--- a/src/Mapper/ResponseMapper.php
+++ b/src/Mapper/ResponseMapper.php
@@ -67,9 +67,9 @@ class ResponseMapper
      *
      * @param string $xmlResponse
      * @param Transaction $transaction
-     * @return Response
      * @throws \InvalidArgumentException
      * @throws MalformedResponseException
+     * @return Response
      */
     public function map($xmlResponse, Transaction $transaction = null)
     {
@@ -103,8 +103,8 @@ class ResponseMapper
     }
 
     /**
-     * @return mixed
      * @throws MalformedResponseException
+     * @return mixed
      */
     private function getPaymentMethod()
     {
@@ -132,8 +132,8 @@ class ResponseMapper
     }
 
     /**
-     * @return string|null
      * @throws \Wirecard\PaymentSdk\Exception\MalformedResponseException
+     * @return string|null
      */
     private function getSuccessRedirectUrl()
     {
@@ -150,9 +150,9 @@ class ResponseMapper
     }
 
     /**
-     * @return FormInteractionResponse
      * @throws \Wirecard\PaymentSdk\Exception\MalformedResponseException
      * @throws \InvalidArgumentException
+     * @return FormInteractionResponse
      */
     private function mapThreeDResponse()
     {
@@ -195,9 +195,9 @@ class ResponseMapper
     }
 
     /**
-     * @return FormInteractionResponse|InteractionResponse|SuccessResponse
      * @throws \InvalidArgumentException
      * @throws MalformedResponseException
+     * @return FormInteractionResponse|InteractionResponse|SuccessResponse
      */
     private function mapSuccessResponse()
     {

--- a/src/Mapper/ResponseMapper.php
+++ b/src/Mapper/ResponseMapper.php
@@ -124,11 +124,12 @@ class ResponseMapper
     }
 
     /**
-     * @param \SimpleXMLElement $paymentMethod
      * @return string|null
+     * @throws \Wirecard\PaymentSdk\Exception\MalformedResponseException
      */
-    private function getRedirectUrl(\SimpleXMLElement $paymentMethod)
+    private function getRedirectUrl()
     {
+        $paymentMethod = $this->getPaymentMethod();
         if (isset($paymentMethod['url'])) {
             return (string)$paymentMethod['url'];
         }
@@ -192,8 +193,8 @@ class ResponseMapper
             return $this->mapThreeDResponse($this->simpleXml, $transaction);
         }
 
-        $paymentMethod = $this->getPaymentMethod();
-        $redirectUrl = $this->getRedirectUrl($paymentMethod);
+        $redirectUrl = $this->getRedirectUrl();
+        if ($transaction->getParentTransactionId())
         if ($redirectUrl !== null) {
             return new InteractionResponse($this->simpleXml, $redirectUrl);
         }

--- a/src/Mapper/ResponseMapper.php
+++ b/src/Mapper/ResponseMapper.php
@@ -61,11 +61,11 @@ class ResponseMapper
      * map the xml Response from engine to ResponseObjects
      *
      * @param string $xmlResponse
-     * @param ThreeDCreditCardTransaction $transaction
+     * @param Transaction $transaction
      * @return Response
      * @throws MalformedResponseException
      */
-    public function map($xmlResponse, ThreeDCreditCardTransaction $transaction = null)
+    public function map($xmlResponse, Transaction $transaction = null)
     {
         $decodedResponse = base64_decode($xmlResponse);
         $xmlResponse = (base64_encode($decodedResponse) === $xmlResponse) ? $decodedResponse : $xmlResponse;
@@ -182,11 +182,11 @@ class ResponseMapper
     }
 
     /**
-     * @param ThreeDCreditCardTransaction $transaction
+     * @param Transaction $transaction
      * @return FormInteractionResponse|InteractionResponse|SuccessResponse
      * @throws MalformedResponseException
      */
-    private function mapSuccessResponse(ThreeDCreditCardTransaction $transaction = null)
+    private function mapSuccessResponse(Transaction $transaction = null)
     {
         if ((string)$this->simpleXml->{'transaction-type'} === ThreeDCreditCardTransaction::TYPE_CHECK_ENROLLMENT) {
             return $this->mapThreeDResponse($this->simpleXml, $transaction);

--- a/src/Transaction/Transaction.php
+++ b/src/Transaction/Transaction.php
@@ -356,4 +356,13 @@ abstract class Transaction
         $this->redirect = $redirect;
         return $this;
     }
+
+    public function getSuccessUrl()
+    {
+        if (null === $this->redirect) {
+            return null;
+        }
+
+        return $this->redirect->getSuccessUrl();
+    }
 }

--- a/src/TransactionService.php
+++ b/src/TransactionService.php
@@ -368,8 +368,7 @@ class TransactionService
         $endpoint = $this->config->getBaseUrl() . $transaction->getEndpoint();
         $responseContent = $this->sendPostRequest($endpoint, $requestBody);
 
-        $data = $transaction instanceof ThreeDCreditCardTransaction ? $transaction : null;
-        return $this->responseMapper->map($responseContent, $data);
+        return $this->responseMapper->map($responseContent, $transaction);
     }
 
     /**

--- a/src/TransactionService.php
+++ b/src/TransactionService.php
@@ -272,6 +272,7 @@ class TransactionService
      * @throws MalformedResponseException
      * @throws UnconfiguredPaymentMethodException
      * @throws \RuntimeException
+     * @throws \InvalidArgumentException
      * @return FailureResponse|InteractionResponse|Response|SuccessResponse
      */
     public function credit(Transaction $transaction)
@@ -344,6 +345,7 @@ class TransactionService
      * @throws UnconfiguredPaymentMethodException
      * @throws MalformedResponseException
      * @throws \RuntimeException
+     * @throws \InvalidArgumentException
      * @return FailureResponse|InteractionResponse|Response|SuccessResponse
      */
     public function process(Transaction $transaction, $operation)
@@ -394,6 +396,7 @@ class TransactionService
      * @throws MalformedResponseException
      * @throws UnconfiguredPaymentMethodException
      * @throws \RuntimeException
+     * @throws \InvalidArgumentException
      * @return FailureResponse|InteractionResponse|Response|SuccessResponse
      */
     private function processAuthFrom3DResponse($payload)
@@ -412,6 +415,7 @@ class TransactionService
      * @throws UnconfiguredPaymentMethodException
      * @throws MalformedResponseException
      * @throws \RuntimeException
+     * @throws \InvalidArgumentException
      * @return Response
      */
     private function processFromIdealResponse($payload)

--- a/test/Mapper/ResponseMapperUTest.php
+++ b/test/Mapper/ResponseMapperUTest.php
@@ -40,6 +40,8 @@ use Wirecard\PaymentSdk\Response\PendingResponse;
 use Wirecard\PaymentSdk\Response\SuccessResponse;
 use Wirecard\PaymentSdk\Transaction\CreditCardTransaction;
 use Wirecard\PaymentSdk\Transaction\Operation;
+use Wirecard\PaymentSdk\Transaction\PayPalTransaction;
+use Wirecard\PaymentSdk\Transaction\SepaTransaction;
 use Wirecard\PaymentSdk\Transaction\ThreeDCreditCardTransaction;
 
 /**
@@ -113,7 +115,7 @@ class ResponseMapperUTest extends \PHPUnit_Framework_TestCase
         /**
          * @var $mapped InteractionResponse
          */
-        $mapped = $this->mapper->map($response);
+        $mapped = $this->mapper->map($response, new PayPalTransaction());
         $this->assertInstanceOf(InteractionResponse::class, $mapped);
         /**
          * @var InteractionResponse $mapped
@@ -158,7 +160,7 @@ class ResponseMapperUTest extends \PHPUnit_Framework_TestCase
                         </payment-methods>
                     </payment>')->asXML();
 
-        $mapped = $this->mapper->map($response);
+        $mapped = $this->mapper->map($response, new PayPalTransaction());
         $this->assertInstanceOf(SuccessResponse::class, $mapped);
         /**
          * @var SuccessResponse $mapped
@@ -188,7 +190,7 @@ class ResponseMapperUTest extends \PHPUnit_Framework_TestCase
                         </payment-methods>
                     </payment>')->asXML());
 
-        $mapped = $this->mapper->map($response);
+        $mapped = $this->mapper->map($response, new PayPalTransaction());
         $this->assertInstanceOf(SuccessResponse::class, $mapped);
         /**
          * @var SuccessResponse $mapped
@@ -315,7 +317,7 @@ class ResponseMapperUTest extends \PHPUnit_Framework_TestCase
                         <card-token></card-token>
                     </payment>')->asXML();
 
-        $mapped = $this->mapper->map($payload);
+        $mapped = $this->mapper->map($payload, new PayPalTransaction());
 
         $this->assertInstanceOf(SuccessResponse::class, $mapped);
         $this->assertEquals($payload, $mapped->getRawData());
@@ -499,7 +501,7 @@ class ResponseMapperUTest extends \PHPUnit_Framework_TestCase
                         </payment-methods>
                     </payment>')->asXML();
 
-        $mapped = $this->mapper->map($response);
+        $mapped = $this->mapper->map($response, new PayPalTransaction());
         $this->assertInstanceOf(SuccessResponse::class, $mapped);
         /**
          * @var SuccessResponse $mapped
@@ -533,7 +535,7 @@ class ResponseMapperUTest extends \PHPUnit_Framework_TestCase
                         </payment-methods>
                     </payment>')->asXML();
 
-        $mapped = $this->mapper->map($response);
+        $mapped = $this->mapper->map($response, new PayPalTransaction());
         $this->assertInstanceOf(SuccessResponse::class, $mapped);
         /**
          * @var SuccessResponse $mapped
@@ -556,7 +558,7 @@ class ResponseMapperUTest extends \PHPUnit_Framework_TestCase
         /**
          * @var PendingResponse $mapped
          */
-        $mapped = $this->mapper->map($response);
+        $mapped = $this->mapper->map($response, new SepaTransaction());
         $this->assertInstanceOf(PendingResponse::class, $mapped);
         $this->assertEquals('1234', $mapped->getRequestId());
     }
@@ -569,9 +571,8 @@ class ResponseMapperUTest extends \PHPUnit_Framework_TestCase
      */
     public function testMalformedResponseThrowsException($jsonResponse)
     {
-        $this->mapper->map($jsonResponse);
+        $this->mapper->map($jsonResponse, new PayPalTransaction());
     }
-
 
     /**
      * @expectedException \Wirecard\PaymentSdk\Exception\MalformedResponseException
@@ -608,9 +609,8 @@ class ResponseMapperUTest extends \PHPUnit_Framework_TestCase
                             severity="information"/>
                         </statuses>
                     </payment>';
-        $this->mapper->map($response);
+        $this->mapper->map($response, new PayPalTransaction());
     }
-
 
     /**
      * @expectedException \Wirecard\PaymentSdk\Exception\MalformedResponseException
@@ -636,7 +636,7 @@ class ResponseMapperUTest extends \PHPUnit_Framework_TestCase
                         </statuses>
                         <payment-methods></payment-methods>
                     </payment>';
-        $this->mapper->map($response);
+        $this->mapper->map($response, new PayPalTransaction());
     }
 
     /**
@@ -666,9 +666,8 @@ class ResponseMapperUTest extends \PHPUnit_Framework_TestCase
                             <payment-method></payment-method>
                         </payment-methods>
                     </payment>';
-        $this->mapper->map($response);
+        $this->mapper->map($response, new PayPalTransaction());
     }
-
 
     /**
      * @expectedException \Wirecard\PaymentSdk\Exception\MalformedResponseException
@@ -697,9 +696,8 @@ class ResponseMapperUTest extends \PHPUnit_Framework_TestCase
                             <payment-method></payment-method>
                         </payment-methods>
                     </payment>';
-        $this->mapper->map($response);
+        $this->mapper->map($response, new PayPalTransaction());
     }
-
 
     /**
      * @expectedException \Wirecard\PaymentSdk\Exception\MalformedResponseException
@@ -725,7 +723,6 @@ class ResponseMapperUTest extends \PHPUnit_Framework_TestCase
 
         $this->mapper->map($payload, $transaction);
     }
-
 
     /**
      * @expectedException \Wirecard\PaymentSdk\Exception\MalformedResponseException

--- a/test/Mapper/ResponseMapperUTest.php
+++ b/test/Mapper/ResponseMapperUTest.php
@@ -126,6 +126,27 @@ class ResponseMapperUTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($response, $mapped->getRawData());
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testNon3DCheckEnrollmentThrowsError()
+    {
+        $response = simplexml_load_string('<?xml version="1.0"?><payment>
+                        <transaction-state>success</transaction-state>
+                        <transaction-id>12345</transaction-id>
+                        <transaction-type>check-enrollment</transaction-type>
+                        <request-id>123</request-id>
+                        <statuses>
+                            <status code="200" description="UnitTest" severity="warning"/>
+                        </statuses>
+                        <payment-methods>
+                            <payment-method name="paypal" url="http://www.example.com/redirect-url"/>
+                        </payment-methods>
+                    </payment>')->asXML();
+
+        $this->mapper->map($response, new PayPalTransaction());
+    }
+
     public function testCardTokenReturnsPaymentMethodCreditCard()
     {
         $helper = function () {

--- a/test/Transaction/TransactionUTest.php
+++ b/test/Transaction/TransactionUTest.php
@@ -33,6 +33,7 @@
 namespace WirecardTest\PaymentSdk\Transaction;
 
 use Wirecard\PaymentSdk\Entity\AccountHolder;
+use Wirecard\PaymentSdk\Entity\Redirect;
 use Wirecard\PaymentSdk\Transaction\Operation;
 use Wirecard\PaymentSdk\Transaction\Transaction;
 
@@ -152,5 +153,19 @@ class TransactionUTest extends \PHPUnit_Framework_TestCase
         $tx->method('mappedSpecificProperties')->willReturn([]);
         $tx->setOperation($operation);
         $tx->mappedProperties();
+    }
+
+    public function testGetSuccessUrlHasNoRedirect()
+    {
+        $this->assertEquals(null, $this->tx->getSuccessUrl());
+    }
+
+    public function testGetSuccessUrlHasRedirect()
+    {
+        $successUrl = 'success';
+        $redirect = new Redirect($successUrl, null);
+        $this->tx->setRedirect($redirect);
+
+        $this->assertEquals($successUrl, $this->tx->getSuccessUrl());
     }
 }


### PR DESCRIPTION
Synchronous payment methods can return an InteractionResponse, if the request contained a success URL.
Some small refactorings in ResponseMapper:
 - introduced the instance variable $transaction
 - getRedirectUrl: renamed to getSuccessRedirectUrl
 - getPaymentMethod is called by getSuccessRedirectUrl (instead of passing its result as a parameter)