### PR TITLE
Response constructor refactoring

### DIFF
--- a/src/Response/FailureResponse.php
+++ b/src/Response/FailureResponse.php
@@ -40,4 +40,9 @@ namespace Wirecard\PaymentSdk\Response;
  */
 class FailureResponse extends Response
 {
+    protected function setValueForRequestId()
+    {
+        // Nothing to do.
+        // If the response is a failure, we can not set the request ID.
+    }
 }

--- a/src/Response/Response.php
+++ b/src/Response/Response.php
@@ -79,9 +79,7 @@ abstract class Response
         $this->simpleXml = $simpleXml;
         $this->validSignature = $validSignature;
         $this->statusCollection = $this->generateStatusCollection();
-        if (!($this instanceof FailureResponse)) {
-            $this->requestId = $this->findElement('request-id');
-        }
+        $this->setValueForRequestId();
     }
 
     /**
@@ -121,7 +119,7 @@ abstract class Response
             return (string)$this->simpleXml->{$element};
         }
 
-        throw new MalformedResponseException('Missing '.$element.' in response.');
+        throw new MalformedResponseException('Missing ' . $element . ' in response.');
     }
 
     /**
@@ -188,5 +186,10 @@ abstract class Response
     public function getTransactionType()
     {
         return $this->transactionType;
+    }
+
+    protected function setValueForRequestId()
+    {
+        $this->requestId = $this->findElement('request-id');
     }
 }


### PR DESCRIPTION
Removed if instanceof FailureResponse.
Using overridden method instead.

The basis class should not know, which subclasses extend it.