### PR TITLE
CreditCard refund

### DIFF
--- a/src/Transaction/CreditCardTransaction.php
+++ b/src/Transaction/CreditCardTransaction.php
@@ -266,6 +266,27 @@ class CreditCardTransaction extends Transaction implements Reservable
     }
 
     /**
+     * @throws MandatoryFieldMissingException|UnsupportedOperationException
+     * @return string
+     */
+    protected function retrieveTransactionTypeForRefund()
+    {
+        if (!$this->parentTransactionId) {
+            throw new MandatoryFieldMissingException('No transaction for cancellation set.');
+        }
+
+        switch ($this->parentTransactionType) {
+            case $this::TYPE_PURCHASE:
+            case $this::TYPE_REFERENCED_PURCHASE:
+                return 'refund-purchase';
+            case $this::TYPE_CAPTURE_AUTHORIZATION:
+                return 'refund-capture';
+            default:
+                throw new UnsupportedOperationException('The transaction can not be refunded.');
+        }
+    }
+
+    /**
      * @return string
      */
     protected function retrieveTransactionTypeForCredit()

--- a/src/Transaction/Operation.php
+++ b/src/Transaction/Operation.php
@@ -37,5 +37,6 @@ class Operation
     const RESERVE = 'reserve';
     const PAY = 'pay';
     const CANCEL = 'cancel';
+    const REFUND = 'refund';
     const CREDIT = 'credit';
 }

--- a/src/Transaction/Transaction.php
+++ b/src/Transaction/Transaction.php
@@ -310,6 +310,9 @@ abstract class Transaction
             case Operation::CANCEL:
                 $transactionType = $this->retrieveTransactionTypeForCancel();
                 break;
+            case Operation::REFUND:
+                $transactionType = $this->retrieveTransactionTypeForRefund();
+                break;
             case Operation::CREDIT:
                 $transactionType = $this->retrieveTransactionTypeForCredit();
                 break;
@@ -343,6 +346,15 @@ abstract class Transaction
      * @return string
      */
     protected function retrieveTransactionTypeForCancel()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * @throws UnsupportedOperationException
+     * @return string
+     */
+    protected function retrieveTransactionTypeForRefund()
     {
         throw new UnsupportedOperationException();
     }

--- a/src/TransactionService.php
+++ b/src/TransactionService.php
@@ -278,7 +278,13 @@ class TransactionService
      */
     public function cancel(Transaction $transaction)
     {
-        return $this->process($transaction, Operation::CANCEL);
+        $cancelResult = $this->process($transaction, Operation::CANCEL);
+
+        if ($cancelResult instanceof SuccessResponse) {
+            return $cancelResult;
+        }
+
+        return $this->process($transaction, Operation::REFUND);
     }
 
     /**

--- a/src/TransactionService.php
+++ b/src/TransactionService.php
@@ -280,11 +280,13 @@ class TransactionService
     {
         $cancelResult = $this->process($transaction, Operation::CANCEL);
 
-        if ($cancelResult instanceof SuccessResponse) {
-            return $cancelResult;
+        if ($transaction instanceof CreditCardTransaction
+            && $cancelResult->getStatusCollection()->hasStatusCodes(['500.1057'])
+        ) {
+            return $this->process($transaction, Operation::REFUND);
         }
 
-        return $this->process($transaction, Operation::REFUND);
+        return $cancelResult;
     }
 
     /**

--- a/test/Transaction/TransactionUTest.php
+++ b/test/Transaction/TransactionUTest.php
@@ -124,6 +124,11 @@ class TransactionUTest extends \PHPUnit_Framework_TestCase
                 Transaction::TYPE_VOID_AUTHORIZATION,
             ],
             [
+                Operation::REFUND,
+                'retrieveTransactionTypeForRefund',
+                Transaction::TYPE_CAPTURE_AUTHORIZATION,
+            ],
+            [
                 Operation::CREDIT,
                 'retrieveTransactionTypeForCredit',
                 Transaction::TYPE_CREDIT,

--- a/test/TransactionServiceUTest.php
+++ b/test/TransactionServiceUTest.php
@@ -608,6 +608,41 @@ class TransactionServiceUTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($successResponse, $result);
     }
 
+    public function testCancelRefund()
+    {
+        $mock = new MockHandler([
+            new Response(
+                200,
+                [],
+                '{"payment":{"transaction-type":"capture-authorization"}}'
+            ),
+            new Response(
+                200,
+                [],
+                '<payment><transaction-state>failure</transaction-state><statuses><status code="1" description="a" severity="0"></status></statuses></payment>'
+            ),
+            new Response(
+                200,
+                [],
+                '{"payment":{"transaction-type":"capture-authorization"}}'
+            ),
+            new Response(
+                200,
+                [],
+                '<payment><transaction-type>refund-capture</transaction-type><transaction-id>23tghfrhfgh</transaction-id><request-id>afhnfgdg</request-id><payment-methods><payment-method name="creditcard" /></payment-methods><transaction-state>success</transaction-state><statuses><status code="200.000" description="a" severity="0"></status></statuses></payment>'
+            ),
+        ]);
+
+        $handler = HandlerStack::create($mock);
+        $client = new Client([self::HANDLER => $handler]);
+
+        $this->instance = new TransactionService($this->config, null, $client);
+
+        $tx = new CreditCardTransaction();
+        $tx->setParentTransactionId('parent-id');
+        $this->assertInstanceOf(SuccessResponse::class, $this->instance->cancel($tx));
+    }
+
     public function testCredit()
     {
         $tx = new CreditCardTransaction();

--- a/test/TransactionServiceUTest.php
+++ b/test/TransactionServiceUTest.php
@@ -619,7 +619,10 @@ class TransactionServiceUTest extends \PHPUnit_Framework_TestCase
             new Response(
                 200,
                 [],
-                '<payment><transaction-state>failure</transaction-state><statuses><status code="1" description="a" severity="0"></status></statuses></payment>'
+                '<payment>
+<transaction-state>failure</transaction-state>
+<statuses><status code="1" description="a" severity="0"></status></statuses>
+</payment>'
             ),
             new Response(
                 200,
@@ -629,7 +632,14 @@ class TransactionServiceUTest extends \PHPUnit_Framework_TestCase
             new Response(
                 200,
                 [],
-                '<payment><transaction-type>refund-capture</transaction-type><transaction-id>23tghfrhfgh</transaction-id><request-id>afhnfgdg</request-id><payment-methods><payment-method name="creditcard" /></payment-methods><transaction-state>success</transaction-state><statuses><status code="200.000" description="a" severity="0"></status></statuses></payment>'
+                '<payment>
+<transaction-type>refund-capture</transaction-type>
+<transaction-id>23tghfrhfgh</transaction-id>
+<request-id>afhnfgdg</request-id>
+<payment-methods><payment-method name="creditcard" /></payment-methods>
+<transaction-state>success</transaction-state>
+<statuses><status code="200.000" description="a" severity="0"></status></statuses>
+</payment>'
             ),
         ]);
 

--- a/test/TransactionServiceUTest.php
+++ b/test/TransactionServiceUTest.php
@@ -621,7 +621,7 @@ class TransactionServiceUTest extends \PHPUnit_Framework_TestCase
                 [],
                 '<payment>
 <transaction-state>failure</transaction-state>
-<statuses><status code="1" description="a" severity="0"></status></statuses>
+<statuses><status code="500.1057" description="a" severity="0"></status></statuses>
 </payment>'
             ),
             new Response(


### PR DESCRIPTION
If a purchase or capture of a CreditCardTransaction is already settled, the normal cancel command would fail. So a fallback needed to be added to support already settled transaction in cancel command. This is done by introducing a new operation REFUND and to use it during cancel command if the normal cancel fails.