### PR TITLE
TRWDCEE-585: Unified basket for ratepay* and paypal transactions

### DIFF
--- a/examples/Features/basket.php
+++ b/examples/Features/basket.php
@@ -36,11 +36,12 @@ $notificationUrl = getUrl('notify.php');
 $item1 = new \Wirecard\PaymentSdk\Entity\Item('Item 1', new Amount(2.59, 'EUR'), 1);
 $item1->setArticleNumber('A1');
 $item1->setDescription('My first item');
+$item1->setTaxRate(20.0);
 
 $item2 = new \Wirecard\PaymentSdk\Entity\Item('Item 2', new Amount(5, 'EUR'), 2);
 $item2->setArticleNumber('B2');
 $item2->setDescription('My second item');
-$item2->setTaxAmount(new Amount(1, 'EUR'));
+$item2->setTaxRate(10.0);
 
 // The items are all stored in a `Basket` object.
 $basket = new \Wirecard\PaymentSdk\Entity\Basket();

--- a/examples/RatePAY_DirectDebit/cancel.php
+++ b/examples/RatePAY_DirectDebit/cancel.php
@@ -34,11 +34,11 @@ $orderNumber = 'A2';
 // Create your items.
 $item1 = new \Wirecard\PaymentSdk\Entity\Item('Item 1', new Amount(400, 'EUR'), 1);
 $item1->setArticleNumber('A1');
-$item1->setTaxRate(0.1);
+$item1->setTaxRate(10.0);
 
 $item2 = new \Wirecard\PaymentSdk\Entity\Item('Item 2', new Amount(1000, 'EUR'), 2);
 $item2->setArticleNumber('B2');
-$item2->setTaxRate(0.2);
+$item2->setTaxRate(20.0);
 
 // Create an item collection to store the items.
 $basket = new \Wirecard\PaymentSdk\Entity\Basket();

--- a/examples/RatePAY_DirectDebit/pay-based-on-reserve.php
+++ b/examples/RatePAY_DirectDebit/pay-based-on-reserve.php
@@ -28,11 +28,11 @@ $orderNumber = 'A2';
 
 $item1 = new \Wirecard\PaymentSdk\Entity\Item('Item 1', new Amount(400, 'EUR'), 1);
 $item1->setArticleNumber('A1');
-$item1->setTaxRate(0.1);
+$item1->setTaxRate(10.0);
 
 $item2 = new \Wirecard\PaymentSdk\Entity\Item('Item 2', new Amount(1000, 'EUR'), 2);
 $item2->setArticleNumber('B2');
-$item2->setTaxRate(0.2);
+$item2->setTaxRate(20.0);
 
 // Create a basket to store the items.
 $basket = new \Wirecard\PaymentSdk\Entity\Basket();

--- a/examples/RatePAY_DirectDebit/reserve.php
+++ b/examples/RatePAY_DirectDebit/reserve.php
@@ -39,11 +39,11 @@ $item1 = new item('Item 1', new Amount(400, 'EUR'), 1);
 // In contrast to the [basket example](../Features/basket.html),
 // RatePAY requires the **tax rate** and the ** article number**.
 $item1->setArticleNumber('A1');
-$item1->setTaxRate(0.1);
+$item1->setTaxRate(10.0);
 
 $item2 = new item('Item 2', new Amount(1000, 'EUR'), 2);
 $item2->setArticleNumber('B2');
-$item2->setTaxRate(0.2);
+$item2->setTaxRate(20.0);
 
 // Create a basket to store the items.
 $basket = new \Wirecard\PaymentSdk\Entity\Basket();

--- a/examples/RatePAY_Installment/cancel.php
+++ b/examples/RatePAY_Installment/cancel.php
@@ -30,11 +30,11 @@ $orderNumber = 'A2';
 $item1 = new \Wirecard\PaymentSdk\Entity\Item('Item 1', new Amount(400, 'EUR'), 1);
 $item1->setArticleNumber('A1');
 // In contrast to the [basket example](../Features/basket.html), RatePAY requires the **tax rate**.
-$item1->setTaxRate(0.1);
+$item1->setTaxRate(10.0);
 
 $item2 = new \Wirecard\PaymentSdk\Entity\Item('Item 2', new Amount(1000, 'EUR'), 2);
 $item2->setArticleNumber('B2');
-$item2->setTaxRate(0.2);
+$item2->setTaxRate(20.0);
 
 // Create a basket to store the items.
 $basket = new \Wirecard\PaymentSdk\Entity\Basket();

--- a/examples/RatePAY_Installment/pay-based-on-reserve.php
+++ b/examples/RatePAY_Installment/pay-based-on-reserve.php
@@ -34,11 +34,11 @@ $item1 = new \Wirecard\PaymentSdk\Entity\Item('Item 1', new Amount(400, 'EUR'), 
 // In contrast to the [basket example](../Features/basket.html),
 // RatePAY requires the **tax rate** and the ** article number**.
 $item1->setArticleNumber('A1');
-$item1->setTaxRate(0.1);
+$item1->setTaxRate(10.0);
 
 $item2 = new \Wirecard\PaymentSdk\Entity\Item('Item 2', new Amount(1000, 'EUR'), 2);
 $item2->setArticleNumber('B2');
-$item2->setTaxRate(0.2);
+$item2->setTaxRate(20.0);
 
 // Create a basket collection to store the items.
 $basket = new \Wirecard\PaymentSdk\Entity\Basket();

--- a/examples/RatePAY_Installment/reserve.php
+++ b/examples/RatePAY_Installment/reserve.php
@@ -46,11 +46,11 @@ $item1 = new \Wirecard\PaymentSdk\Entity\Item('Item 1', new Amount(400, 'EUR'), 
 // In contrast to the [basket example](../Features/basket.html),
 // RatePAY requires the **tax rate** and the ** article number**.
 $item1->setArticleNumber('A1');
-$item1->setTaxRate(0.1);
+$item1->setTaxRate(10.0);
 
 $item2 = new \Wirecard\PaymentSdk\Entity\Item('Item 2', new Amount(1000, 'EUR'), 2);
 $item2->setArticleNumber('B2');
-$item2->setTaxRate(0.2);
+$item2->setTaxRate(20.0);
 
 // Create a basket to store the items.
 $basket = new \Wirecard\PaymentSdk\Entity\Basket();

--- a/examples/RatePAY_Invoice/cancel.php
+++ b/examples/RatePAY_Invoice/cancel.php
@@ -30,11 +30,11 @@ $orderNumber = 'A2';
 // Create your items.
 $item1 = new \Wirecard\PaymentSdk\Entity\Item('Item 1', new Amount(400, 'EUR'), 1);
 $item1->setArticleNumber('A1');
-$item1->setTaxRate(0.1);
+$item1->setTaxRate(10.0);
 
 $item2 = new \Wirecard\PaymentSdk\Entity\Item('Item 2', new Amount(1000, 'EUR'), 2);
 $item2->setArticleNumber('B2');
-$item2->setTaxRate(0.2);
+$item2->setTaxRate(20.0);
 
 // Create an item collection to store the items.
 $basket = new \Wirecard\PaymentSdk\Entity\Basket();

--- a/examples/RatePAY_Invoice/pay-based-on-reserve.php
+++ b/examples/RatePAY_Invoice/pay-based-on-reserve.php
@@ -28,11 +28,11 @@ $orderNumber = 'A2';
 
 $item1 = new \Wirecard\PaymentSdk\Entity\Item('Item 1', new Amount(400, 'EUR'), 1);
 $item1->setArticleNumber('A1');
-$item1->setTaxRate(0.1);
+$item1->setTaxRate(10.0);
 
 $item2 = new \Wirecard\PaymentSdk\Entity\Item('Item 2', new Amount(1000, 'EUR'), 2);
 $item2->setArticleNumber('B2');
-$item2->setTaxRate(0.2);
+$item2->setTaxRate(20.0);
 
 // Create a basket to store the items.
 $basket = new \Wirecard\PaymentSdk\Entity\Basket();

--- a/examples/RatePAY_Invoice/reserve.php
+++ b/examples/RatePAY_Invoice/reserve.php
@@ -37,11 +37,11 @@ $item1 = new \Wirecard\PaymentSdk\Entity\Item('Item 1', new Amount(400, 'EUR'), 
 // In contrast to the [basket example](../Features/basket.html),
 // RatePAY requires the **tax rate** and the ** article number**.
 $item1->setArticleNumber('A1');
-$item1->setTaxRate(0.1);
+$item1->setTaxRate(10.0);
 
 $item2 = new \Wirecard\PaymentSdk\Entity\Item('Item 2', new Amount(1000, 'EUR'), 2);
 $item2->setArticleNumber('B2');
-$item2->setTaxRate(0.2);
+$item2->setTaxRate(20.0);
 
 // Create a basket to store the items.
 $basket = new \Wirecard\PaymentSdk\Entity\Basket();

--- a/src/Entity/Basket.php
+++ b/src/Entity/Basket.php
@@ -33,6 +33,7 @@
 namespace Wirecard\PaymentSdk\Entity;
 
 use Traversable;
+use Wirecard\PaymentSdk\Exception\MandatoryFieldMissingException;
 
 /**
  * Class Basket
@@ -44,6 +45,21 @@ class Basket implements \IteratorAggregate, MappableEntity
      * @var array
      */
     private $items = [];
+
+    /**
+     * @var string
+     */
+    private $version;
+
+    /**
+     * @param string $version
+     * @return $this
+     */
+    public function setVersion($version)
+    {
+        $this->version = $version;
+        return $this;
+    }
 
     /**
      * Retrieve an external iterator
@@ -69,6 +85,7 @@ class Basket implements \IteratorAggregate, MappableEntity
     }
 
     /**
+     * @throws MandatoryFieldMissingException
      * @return array
      */
     public function mappedProperties()
@@ -79,6 +96,7 @@ class Basket implements \IteratorAggregate, MappableEntity
          * @var Item $item
          */
         foreach ($this->getIterator() as $item) {
+            $item->setVersion($this->version);
             $data['order-item'][] = $item->mappedProperties();
         }
 

--- a/src/Transaction/PayPalTransaction.php
+++ b/src/Transaction/PayPalTransaction.php
@@ -33,6 +33,7 @@
 namespace Wirecard\PaymentSdk\Transaction;
 
 use Wirecard\PaymentSdk\Entity\AccountHolder;
+use Wirecard\PaymentSdk\Entity\Basket;
 use Wirecard\PaymentSdk\Exception\MandatoryFieldMissingException;
 use Wirecard\PaymentSdk\Exception\UnsupportedOperationException;
 
@@ -63,6 +64,11 @@ class PayPalTransaction extends Transaction implements Reservable
      * @var AccountHolder
      */
     private $shipping;
+
+    /**
+     * @var Basket
+     */
+    protected $basket;
 
     /**
      * @param AccountHolder $shipping
@@ -101,6 +107,16 @@ class PayPalTransaction extends Transaction implements Reservable
     public function setOrderDetail($orderDetail)
     {
         $this->orderDetail = $orderDetail;
+        return $this;
+    }
+
+    /**
+     * @param Basket $basket
+     * @return Transaction
+     */
+    public function setBasket(Basket $basket)
+    {
+        $this->basket = $basket;
         return $this;
     }
 
@@ -144,6 +160,11 @@ class PayPalTransaction extends Transaction implements Reservable
 
         if (null !== $this->descriptor) {
             $data['descriptor'] = $this->descriptor;
+        }
+
+        if ($this->basket instanceof Basket) {
+            $this->basket->setVersion(self::class);
+            $data['order-items'] = $this->basket->mappedProperties();
         }
 
         return $data;

--- a/src/Transaction/RatepayTransaction.php
+++ b/src/Transaction/RatepayTransaction.php
@@ -32,6 +32,8 @@
 
 namespace Wirecard\PaymentSdk\Transaction;
 
+use Wirecard\PaymentSdk\Entity\Basket;
+use Wirecard\PaymentSdk\Entity\Device;
 use Wirecard\PaymentSdk\Exception\MandatoryFieldMissingException;
 use Wirecard\PaymentSdk\Exception\UnsupportedOperationException;
 
@@ -54,6 +56,11 @@ class RatepayTransaction extends Transaction implements Reservable
     protected $device;
 
     /**
+     * @var Basket
+     */
+    protected $basket;
+
+    /**
      * @param string $orderNumber
      * @return RatepayTransaction
      */
@@ -74,6 +81,16 @@ class RatepayTransaction extends Transaction implements Reservable
     }
 
     /**
+     * @param Basket $basket
+     * @return Transaction
+     */
+    public function setBasket(Basket $basket)
+    {
+        $this->basket = $basket;
+        return $this;
+    }
+
+    /**
      * @throws MandatoryFieldMissingException|UnsupportedOperationException
      * @return array
      */
@@ -82,8 +99,14 @@ class RatepayTransaction extends Transaction implements Reservable
         $result = [
             'order-number' => $this->orderNumber,
         ];
+
         if (null !== $this->device) {
             $result['device'] = $this->device->mappedProperties();
+        }
+
+        if ($this->basket instanceof Basket) {
+            $this->basket->setVersion(self::class);
+            $result['order-items'] = $this->basket->mappedProperties();
         }
 
         return $result;

--- a/src/Transaction/Transaction.php
+++ b/src/Transaction/Transaction.php
@@ -36,7 +36,6 @@ use Locale;
 use Wirecard\PaymentSdk\Entity\AccountHolder;
 use Wirecard\PaymentSdk\Entity\Amount;
 use Wirecard\PaymentSdk\Entity\CustomFieldCollection;
-use Wirecard\PaymentSdk\Entity\Basket;
 use Wirecard\PaymentSdk\Entity\Redirect;
 use Wirecard\PaymentSdk\Exception\MandatoryFieldMissingException;
 use Wirecard\PaymentSdk\Exception\UnsupportedOperationException;
@@ -80,11 +79,6 @@ abstract class Transaction
      * @var string
      */
     protected $consumerId;
-
-    /**
-     * @var Basket
-     */
-    protected $basket;
 
     /**
      * @var string
@@ -177,16 +171,6 @@ abstract class Transaction
     public function setAmount($amount)
     {
         $this->amount = $amount;
-    }
-
-    /**
-     * @param Basket $basket
-     * @return Transaction
-     */
-    public function setBasket(Basket $basket)
-    {
-        $this->basket = $basket;
-        return $this;
     }
 
     /**
@@ -291,10 +275,6 @@ abstract class Transaction
             if ($this->redirect->getFailureUrl()) {
                 $result['fail-redirect-url'] = $this->redirect->getFailureUrl();
             }
-        }
-
-        if ($this->basket instanceof Basket) {
-            $result['order-items'] = $this->basket->mappedProperties();
         }
 
         if (null !== $this->consumerId) {

--- a/test/Entity/ItemUTest.php
+++ b/test/Entity/ItemUTest.php
@@ -64,6 +64,7 @@ namespace WirecardTest\PaymentSdk\Entity;
 
 use Wirecard\PaymentSdk\Entity\Item;
 use Wirecard\PaymentSdk\Entity\Amount;
+use Wirecard\PaymentSdk\Transaction\PayPalTransaction;
 
 class ItemUTest extends \PHPUnit_Framework_TestCase
 {
@@ -102,10 +103,9 @@ class ItemUTest extends \PHPUnit_Framework_TestCase
 
     public function testMappedPropertiesWithAllProperties()
     {
-        $this->item->setTaxAmount(new Amount(0.1, 'EUR'));
         $this->item->setArticleNumber('1232f5445');
         $this->item->setDescription('dthfbvdfg');
-        $this->item->setTaxRate('0.2');
+        $this->item->setTaxRate(20.0);
 
         $expected = [
             'name' => self::NAME,
@@ -115,12 +115,33 @@ class ItemUTest extends \PHPUnit_Framework_TestCase
                 'value' => '1',
                 'currency' => 'EUR'
             ],
+            'quantity' => self::QUANTITY,
+            'tax-rate' => '0.2'
+        ];
+
+        $this->assertEquals($expected, $this->item->mappedProperties());
+    }
+
+    public function testMappedPropertiesWithAllPropertiesForPayPal()
+    {
+        $this->item->setVersion(PayPalTransaction::class);
+        $this->item->setArticleNumber('1232f5445');
+        $this->item->setDescription('dthfbvdfg');
+        $this->item->setTaxRate(10.0);
+
+        $expected = [
+            'name' => self::NAME,
+            'description' => 'dthfbvdfg',
+            'article-number' => '1232f5445',
+            'amount' => [
+                'value' => '1',
+                'currency' => 'EUR'
+            ],
+            'quantity' => self::QUANTITY,
             'tax-amount' => [
                 'value' => '0.1',
                 'currency' => 'EUR'
             ],
-            'quantity' => self::QUANTITY,
-            'tax-rate' => '0.2'
         ];
 
         $this->assertEquals($expected, $this->item->mappedProperties());

--- a/test/Entity/ItemUTest.php
+++ b/test/Entity/ItemUTest.php
@@ -116,7 +116,7 @@ class ItemUTest extends \PHPUnit_Framework_TestCase
                 'currency' => 'EUR'
             ],
             'quantity' => self::QUANTITY,
-            'tax-rate' => '0.2'
+            'tax-rate' => 20.0
         ];
 
         $this->assertEquals($expected, $this->item->mappedProperties());


### PR DESCRIPTION
Removed item taxAmount.

paymentSdk is only providing taxRate, amount and quantity anymore for items.

Tax amount will be calculated for paypal.

Basket will be send for Paypal and all Ratepay based transaction