### PR TITLE
Optimize noneThree3D Fallback

### DIFF
--- a/src/TransactionService.php
+++ b/src/TransactionService.php
@@ -638,9 +638,8 @@ class TransactionService
         }
 
         if ($transaction instanceof CreditCardTransaction
-            && $response instanceof FailureResponse
-            && $transaction->isFallback()
             && $response->getStatusCollection()->hasStatusCodes(['500.1072', '500.1073', '500.1074'])
+            && $transaction->isFallback())
         ) {
             $response = $this->processFallback($transaction);
         }
@@ -849,7 +848,7 @@ class TransactionService
             return $ret;
         }
     }
-    
+
     /**
      * Access to the configuration object which was set in constructor
      *

--- a/src/TransactionService.php
+++ b/src/TransactionService.php
@@ -638,6 +638,7 @@ class TransactionService
         }
 
         if ($transaction instanceof CreditCardTransaction
+            && $response instanceof FailureResponse
             && $transaction->isFallback()
             && $response->getStatusCollection()->hasStatusCodes(['500.1072', '500.1073', '500.1074'])
         ) {

--- a/src/TransactionService.php
+++ b/src/TransactionService.php
@@ -635,7 +635,9 @@ class TransactionService
             $response->setOperation($operation);
         }
 
-        if ($transaction instanceof CreditCardTransaction && $response instanceof FailureResponse && $transaction->isFallback()) {
+        if ($transaction instanceof CreditCardTransaction 
+            && $response instanceof FailureResponse 
+            && $transaction->isFallback()) {
             if (!$response->getStatusCollection()->hasStatusCodes(['500.1072', '500.1073', '500.1074'])) {
                 return $response;
             }
@@ -660,7 +662,7 @@ class TransactionService
      * @return Response
      */
     private function processFallback(CreditCardTransaction $transaction, Response $response)
-    {        
+    {
         $transaction->setThreeD(false);
         $requestBody = $this->requestMapper->map($transaction);
         $endpoint = $this->config->getBaseUrl() . $transaction->getEndpoint();

--- a/src/TransactionService.php
+++ b/src/TransactionService.php
@@ -635,8 +635,8 @@ class TransactionService
             $response->setOperation($operation);
         }
 
-        if ($transaction instanceof CreditCardTransaction 
-            && $response instanceof FailureResponse 
+        if ($transaction instanceof CreditCardTransaction
+            && $response instanceof FailureResponse
             && $transaction->isFallback()) {
             if (!$response->getStatusCollection()->hasStatusCodes(['500.1072', '500.1073', '500.1074'])) {
                 return $response;

--- a/src/TransactionService.php
+++ b/src/TransactionService.php
@@ -639,7 +639,7 @@ class TransactionService
 
         if ($transaction instanceof CreditCardTransaction
             && $response->getStatusCollection()->hasStatusCodes(['500.1072', '500.1073', '500.1074'])
-            && $transaction->isFallback())
+            && $transaction->isFallback()
         ) {
             $response = $this->processFallback($transaction);
         }

--- a/src/TransactionService.php
+++ b/src/TransactionService.php
@@ -635,7 +635,11 @@ class TransactionService
             $response->setOperation($operation);
         }
 
-        if ($transaction instanceof CreditCardTransaction && $transaction->isFallback()) {
+        if ($transaction instanceof CreditCardTransaction && $response instanceof FailureResponse && $transaction->isFallback()) {
+            if (!$response->getStatusCollection()->hasStatusCodes(['500.1072', '500.1073', '500.1074'])) {
+                return $response;
+            }
+    
             return $this->processFallback($transaction, $response);
         }
 
@@ -656,11 +660,7 @@ class TransactionService
      * @return Response
      */
     private function processFallback(CreditCardTransaction $transaction, Response $response)
-    {
-        if (!$response->getStatusCollection()->hasStatusCodes(['500.1072', '500.1073', '500.1074'])) {
-            return $response;
-        }
-
+    {        
         $transaction->setThreeD(false);
         $requestBody = $this->requestMapper->map($transaction);
         $endpoint = $this->config->getBaseUrl() . $transaction->getEndpoint();


### PR DESCRIPTION
Before processing the non ThreeD fallback check if the response has failed.
Move status codes checks out of process fallback for better readability.