### PR TITLE
Add PHP 7.4 as a supported version

### DIFF
--- a/.github/workflows/run_cs_unit_coverage.yml
+++ b/.github/workflows/run_cs_unit_coverage.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: ['5.6', '7.0', '7.1', '7.2', '7.3']
+        php-versions: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4']
     name: PHP ${{ matrix.php-versions }} Test
     steps:
     - name: Checkout

--- a/.github/workflows/run_mutation.yml
+++ b/.github/workflows/run_mutation.yml
@@ -3,9 +3,9 @@ name: Mutation tests
 on: [push]
 
 jobs:
-  run:    
+  run:
     runs-on: ubuntu-latest
-    name: PHP 7.3 Mutation Test
+    name: PHP 7.4 Mutation Test
     steps:
     - name: Checkout
       uses: wirecard/checkout@v2.0.0
@@ -13,13 +13,13 @@ jobs:
     - name: Setup PHP
       uses: wirecard/setup-php@master
       with:
-        php-version: 7.3
+        php-version: 7.4
         extension-csv: mbstring, intl, simplexml, dom
         ini-values-csv: post_max_size=256M, short_open_tag=On
         coverage: xdebug
         pecl: false
 
-    - name: Composer install 
+    - name: Composer install
       run: composer require --dev --no-interaction infection/infection:0.12.2
 
     - name: Run Mutation Tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,13 +33,13 @@ jobs:
         - ALLOW_FAIL=1
   include:
     - stage: Generate tags
-      php: 7.3
+      php: 7.4
       if: branch = master AND type != pull_request
       script: bash .bin/generate-tag.sh
 
     - stage: Generate release package
       if: tag IS present
-      php: 7.3
+      php: 7.4
       script: skip
       before_deploy:
         - bash .bin/generate-release-package.sh $TRAVIS_TAG

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "ext-libxml": "*",
     "ext-dom": "*",
     "ext-hash": "*",
-    "php": "5.6.* || 7.0.* || 7.1.* || 7.2.* || 7.3.*",
+    "php": "5.6.* || 7.0.* || 7.1.* || 7.2.* || 7.3.* || 7.4.*",
     "monolog/monolog": "^1.16",
     "php-http/client-common": "^1.0",
     "php-http/discovery": "^1.0 <= 1.6.1",


### PR DESCRIPTION
 - Adds PHP7.4 as a supported version
 - Skim through https://www.php.net/manual/en/migration74.incompatible.php
   and seems like everything is ok
 - PHP7.4 was released in Novemeber 2019 should support it